### PR TITLE
Allow keeping the webserver & client active even after test teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Unlike testing and web scraping libraries you're used to, Panther:
 When you use the Panther client, the web server running in background will be started at runtime and stopped at test's
 teardown.
 
-If you want to save a few performances and launch the server at PHPUnit startup, you can add the `ServerListener` to
+If you want to improve performances and launch the server at PHPUnit startup, you can add the `ServerListener` to
 your PHPUnit configuration:
 
 ```xml

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ your PHPUnit configuration:
 <!-- phpunit.xml.dist -->
 
     <listeners>
-        <listener class="Panthere\ServerListener" />
+        <listener class="Panther\ServerListener" />
     </listeners>
 ```
 

--- a/README.md
+++ b/README.md
@@ -166,9 +166,9 @@ Unlike testing and web scraping libraries you're used to, Panther:
 * supports custom [Selenium server](https://www.seleniumhq.org) installations
 * supports remote browser testing services including [SauceLabs](https://saucelabs.com/) and [BrowserStack](https://www.browserstack.com/)
 
-### Use the `ServerListener` to always have a running web server
+### Using the `ServerListener` to Always Have a Running Web Server
 
-When you use the Panthère client, the web server running in background will be started at runtime and stopped at test's
+When you use the Panther client, the web server running in background will be started at runtime and stopped at test's
 teardown.
 
 If you want to save a few performances and launch the server at PHPUnit startup, you can add the `ServerListener` to
@@ -178,7 +178,7 @@ your PHPUnit configuration:
 <!-- phpunit.xml.dist -->
 
     <listeners>
-        <listener class="Panther\ServerListener" />
+        <listener class="Symfony\Component\Panther\ServerListener" />
     </listeners>
 ```
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,24 @@ Unlike testing and web scraping libraries you're used to, Panther:
 * supports custom [Selenium server](https://www.seleniumhq.org) installations
 * supports remote browser testing services including [SauceLabs](https://saucelabs.com/) and [BrowserStack](https://www.browserstack.com/)
 
+### Use the `ServerListener` to always have a running web server
+
+When you use the Panthère client, the web server running in background will be started at runtime and stopped at test's
+teardown.
+
+If you want to save a few performances and launch the server at PHPUnit startup, you can add the `ServerListener` to
+your PHPUnit configuration:
+
+```xml
+<!-- phpunit.xml.dist -->
+
+    <listeners>
+        <listener class="Panthere\ServerListener" />
+    </listeners>
+```
+
+The listener will start the webserver when the test suite is started, and will stop it when all your tests are executed.
+
 ## Documentation
 
 Since Panther implements the API of popular libraries, it already has an extensive documentation:

--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -27,6 +27,11 @@ use Symfony\Component\Panther\ProcessManager\WebServerManager;
 trait PantherTestCaseTrait
 {
     /**
+     * @var bool
+     */
+    public static $stopServerOnTeardown = true;
+
+    /**
      * @var string|null
      */
     protected static $webServerDir;
@@ -50,21 +55,6 @@ trait PantherTestCaseTrait
      * @var PantherClient|null
      */
     protected static $pantherClient;
-
-    /**
-     * @var bool
-     */
-    private static $stopServerOnTeardown = true;
-
-    public static function stopServerOnTeardown()
-    {
-        self::$stopServerOnTeardown = true;
-    }
-
-    public static function keepServerOnTeardown()
-    {
-        self::$stopServerOnTeardown = false;
-    }
 
     public static function tearDownAfterClass()
     {

--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -51,7 +51,29 @@ trait PantherTestCaseTrait
      */
     protected static $pantherClient;
 
+    /**
+     * @var bool
+     */
+    private static $stopServerOnTeardown = true;
+
+    public static function stopServerOnTeardown()
+    {
+        self::$stopServerOnTeardown = true;
+    }
+
+    public static function keepServerOnTeardown()
+    {
+        self::$stopServerOnTeardown = false;
+    }
+
     public static function tearDownAfterClass()
+    {
+        if (true === self::$stopServerOnTeardown) {
+            static::stopWebServer();
+        }
+    }
+
+    public static function stopWebServer()
     {
         if (null !== self::$webServerManager) {
             self::$webServerManager->quit();
@@ -70,7 +92,7 @@ trait PantherTestCaseTrait
         self::$baseUri = null;
     }
 
-    protected static function startWebServer(?string $webServerDir = null, string $hostname = '127.0.0.1', int $port = 9000): void
+    public static function startWebServer(?string $webServerDir = null, string $hostname = '127.0.0.1', int $port = 9000): void
     {
         if (null !== static::$webServerManager) {
             return;

--- a/src/ServerListener.php
+++ b/src/ServerListener.php
@@ -24,13 +24,13 @@ final class ServerListener implements TestListener
     public function startTestSuite(TestSuite $suite): void
     {
         echo "Starting Panther server for test suite {$suite->getName()}...\n";
-        PantherTestCase::stopServerOnTeardown();
-        PantherTestCase::startWebServer();
+        PantherTestCaseTrait::$stopServerOnTeardown = true;
+        PantherTestCaseTrait::startWebServer();
     }
 
     public function endTestSuite(TestSuite $suite): void
     {
         echo "\nShutting down Panther server...\n";
-        PantherTestCase::stopWebServer();
+        PantherTestCaseTrait::stopWebServer();
     }
 }

--- a/src/ServerListener.php
+++ b/src/ServerListener.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Panthère project.
+ * This file is part of the Panther project.
  *
  * (c) Kévin Dunglas <dunglas@gmail.com>
  *
@@ -11,13 +11,13 @@
 
 declare(strict_types=1);
 
-namespace Panther;
+namespace Symfony\Component\Panther;
 
 use PHPUnit\Framework\TestListener;
 use PHPUnit\Framework\TestListenerDefaultImplementation;
 use PHPUnit\Framework\TestSuite;
 
-class ServerListener implements TestListener
+final class ServerListener implements TestListener
 {
     use TestListenerDefaultImplementation;
 
@@ -25,11 +25,7 @@ class ServerListener implements TestListener
     {
         echo "Starting Panther server for test suite {$suite->getName()}...\n";
         PantherTestCase::stopServerOnTeardown();
-        PantherTestCase::startWebServer(
-            getenv('PANTHER_LISTENER_SERVER_DIR') ?: null,
-            getenv('PANTHER_LISTENER_HOSTNAME') ?: '127.0.0.1',
-            getenv('PANTHER_LISTENER_PORT') ?: 9000
-        );
+        PantherTestCase::startWebServer();
     }
 
     public function endTestSuite(TestSuite $suite): void

--- a/src/ServerListener.php
+++ b/src/ServerListener.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Panthere;
+namespace Panther;
 
 use PHPUnit\Framework\TestListener;
 use PHPUnit\Framework\TestListenerDefaultImplementation;
@@ -23,18 +23,18 @@ class ServerListener implements TestListener
 
     public function startTestSuite(TestSuite $suite): void
     {
-        echo "Starting Panthere server for test suite {$suite->getName()}...\n";
-        PanthereTestCase::stopServerOnTeardown();
-        PanthereTestCase::startWebServer(
-            getenv('PANTHERE_LISTENER_SERVER_DIR') ?: null,
-            getenv('PANTHERE_LISTENER_HOSTNAME') ?: '127.0.0.1',
-            getenv('PANTHERE_LISTENER_PORT') ?: 9000
+        echo "Starting Panther server for test suite {$suite->getName()}...\n";
+        PantherTestCase::stopServerOnTeardown();
+        PantherTestCase::startWebServer(
+            getenv('PANTHER_LISTENER_SERVER_DIR') ?: null,
+            getenv('PANTHER_LISTENER_HOSTNAME') ?: '127.0.0.1',
+            getenv('PANTHER_LISTENER_PORT') ?: 9000
         );
     }
 
     public function endTestSuite(TestSuite $suite): void
     {
-        echo "\nShutting down Panthere server...\n";
-        PanthereTestCase::stopWebServer();
+        echo "\nShutting down Panther server...\n";
+        PantherTestCase::stopWebServer();
     }
 }

--- a/src/ServerListener.php
+++ b/src/ServerListener.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Panthère project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Panthere;
+
+use PHPUnit\Framework\TestListener;
+use PHPUnit\Framework\TestListenerDefaultImplementation;
+use PHPUnit\Framework\TestSuite;
+
+class ServerListener implements TestListener
+{
+    use TestListenerDefaultImplementation;
+
+    public function startTestSuite(TestSuite $suite): void
+    {
+        echo "Starting Panthere server for test suite {$suite->getName()}...\n";
+        PanthereTestCase::stopServerOnTeardown();
+        PanthereTestCase::startWebServer(
+            getenv('PANTHERE_LISTENER_SERVER_DIR') ?: null,
+            getenv('PANTHERE_LISTENER_HOSTNAME') ?: '127.0.0.1',
+            getenv('PANTHERE_LISTENER_PORT') ?: 9000
+        );
+    }
+
+    public function endTestSuite(TestSuite $suite): void
+    {
+        echo "\nShutting down Panthere server...\n";
+        PanthereTestCase::stopWebServer();
+    }
+}

--- a/tests/ServerListenerTest.php
+++ b/tests/ServerListenerTest.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+ * This file is part of the Panther project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace Symfony\Component\Panther\Tests;
 
 use PHPUnit\Framework\TestSuite;
@@ -7,7 +18,7 @@ use Symfony\Component\Panther\ServerListener;
 
 class ServerListenerTest extends TestCase
 {
-    private function createTestSuite(): TestSuite
+    private function createTestSuite()
     {
         $suite = $this->createMock(TestSuite::class);
         $suite->expects($this->once())->method('getName')->willReturn('Dummy test suite');

--- a/tests/ServerListenerTest.php
+++ b/tests/ServerListenerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Symfony\Component\Panther\Tests;
+
+use PHPUnit\Framework\TestSuite;
+use Symfony\Component\Panther\ServerListener;
+
+class ServerListenerTest extends TestCase
+{
+    private function createTestSuite(): TestSuite
+    {
+        $suite = $this->createMock(TestSuite::class);
+        $suite->expects($this->once())->method('getName')->willReturn('Dummy test suite');
+
+        return $suite;
+    }
+
+    public function testStartAndStop(): void
+    {
+        $this->expectOutputString("Starting Panther server for test suite Dummy test suite...\n\nShutting down Panther server...\n");
+
+        $_SERVER['PANTHER_WEB_SERVER_DIR'] = static::$webServerDir;
+
+        $streamContext = stream_context_create(['http' => [
+            'ignore_errors' => true,
+            'protocol_version' => '1.1',
+            'header' => ['Connection: close'],
+            'timeout' => 1,
+        ]]);
+
+        $healthCheck = function () use ($streamContext) {
+            return @file_get_contents('http://127.0.0.1:9000', false, $streamContext);
+        };
+
+        $testSuite = $this->createTestSuite();
+
+        $listener = new ServerListener();
+        $listener->startTestSuite($testSuite);
+
+        // Means the server rendered a 404, so server is running.
+        static::assertContains('<title>404 Not Found</title>', $healthCheck());
+
+        $listener->endTestSuite($testSuite);
+
+        // False means that ping failed.
+        static::assertFalse($healthCheck());
+    }
+}


### PR DESCRIPTION
By keeping the server enabled, we try to guarantee more performances (at least this should be benchmarked)