### PR TITLE
Make update.sh compatible with sh

### DIFF
--- a/chromedriver-bin/update.sh
+++ b/chromedriver-bin/update.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Author: Kévin Dunglas <dunglas@gmail.com>
 # Download the last version of ChromeDriver binaries
 
@@ -6,15 +6,23 @@ latest=$(curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE)
 
 echo "Downloading ChromeDriver version ${latest}..."
 
-declare -a binaries=("chromedriver_linux64" "chromedriver_mac64" "chromedriver_win32")
-for name in "${binaries[@]}"
+binaries="chromedriver_linux64 chromedriver_mac64 chromedriver_win32"
+
+for name in ${binaries}
 do
-   curl -s https://chromedriver.storage.googleapis.com/${latest}/${name}.zip -O
-   unzip -q -o ${name}.zip
-   rm ${name}.zip
-   if [ -f "chromedriver" ]; then
-      mv chromedriver ${name}
-   fi
+    echo -ne "${name}"
+
+    curl -s https://chromedriver.storage.googleapis.com/${latest}/${name}.zip -O
+    unzip -q -o ${name}.zip
+    rm ${name}.zip
+    if [ -f "chromedriver" ]; then
+        mv chromedriver ${name}
+    fi
+    echo -ne ": Ok!"
+    echo ""
 done
+
+echo "Downloading release notes..."
 curl -s https://chromedriver.storage.googleapis.com/${latest}/notes.txt -O
+
 echo "Done."


### PR DESCRIPTION
Else, the update can't be made on non-bash shells (such as Alpine for example).

IMO it's better to stick to `sh` which is available almost everywhere 