### PR TITLE
Allow injecting env vars to web server process

### DIFF
--- a/src/PanthereTestCaseTrait.php
+++ b/src/PanthereTestCaseTrait.php
@@ -71,8 +71,7 @@ trait PanthereTestCaseTrait
         self::$baseUri = null;
     }
 
-    protected static function startWebServer(?string $webServerDir = null, string $hostname = '127.0.0.1', int $port = 9000): void
-    {
+    protected static function startWebServer(?string $webServerDir = null, string $hostname = '127.0.0.1', int $port = 9000, array $env = []): void {
         if (null !== static::$webServerManager) {
             return;
         }
@@ -82,7 +81,7 @@ trait PanthereTestCaseTrait
             $webServerDir = static::$webServerDir ?? $_ENV['PANTHERE_WEB_SERVER_DIR'] ?? __DIR__.'/../../../../public';
         }
 
-        self::$webServerManager = new WebServerManager($webServerDir, $hostname, $port);
+        self::$webServerManager = new WebServerManager($webServerDir, $hostname, $port, $env);
         self::$webServerManager->start();
 
         self::$baseUri = "http://$hostname:$port";

--- a/src/ProcessManager/WebServerManager.php
+++ b/src/ProcessManager/WebServerManager.php
@@ -34,7 +34,7 @@ final class WebServerManager
     /**
      * @throws \RuntimeException
      */
-    public function __construct(string $documentRoot, string $hostname, int $port)
+    public function __construct(string $documentRoot, string $hostname, int $port, array $env = [])
     {
         $this->hostname = $hostname;
         $this->port = $port;
@@ -57,7 +57,7 @@ final class WebServerManager
                 ]
             ),
             $documentRoot,
-            null,
+            $env,
             null,
             null
         );


### PR DESCRIPTION
After I closed #18 I forgot to make another PR for this part.

I think it's essential to automatically inject env vars.

As we are using PHPUnit, env vars for the test execution should be set in `phpunit.xml.dist`, therefore they'll be available in `$_ENV` thanks to PHPUnit, so we can safely inject them in the process.

This will avoid it use the `.env` file when using the full-stack setup, and make sure we can isolate test env from dev env when using the same machine for both.

