### PR TITLE
fixed waitFor return type error

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -226,7 +226,7 @@ final class Client extends BaseClient implements WebDriver
         return new CookieJar($this->webDriver);
     }
 
-    public function waitFor(string $cssSelector, int $timeoutInSecond = 30, int $intervalInMillisecond = 250): object
+    public function waitFor(string $cssSelector, int $timeoutInSecond = 30, int $intervalInMillisecond = 250)
     {
         return $this->wait($timeoutInSecond, $intervalInMillisecond)->until(
             WebDriverExpectedCondition::visibilityOfElementLocated(WebDriverBy::cssSelector($cssSelector))


### PR DESCRIPTION
In browser tests I got an exception:

> TypeError : Return value of Symfony\Component\Panthere\Client::waitFor() must be an instance of Symfony\Component\Panthere\object, instance of Facebook\WebDriver\Remote\RemoteWebElement returned

Of course, `\object` and `\stdClass` didn't pass as return types, so it appears the method should be without one. Come to think about it, can it return anything other than `RemoteWebElement`?