### PR TITLE
Ability to add custom arguments for Chrome Driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ The following environment variables can be set to change some Panther behaviors:
 * `PANTHER_NO_SANDBOX`: to disable [Chrome's sandboxing](https://chromium.googlesource.com/chromium/src/+/b4730a0c2773d8f6728946013eb812c6d3975bec/docs/design/sandbox.md) (unsafe, but allows to use Panther in containers)
 * `PANTHER_WEB_SERVER_DIR`: to change the project's document root (default to `public/`)
 * `PANTHER_CHROME_DRIVER_BINARY`: to use another `chromedriver` binary, instead of relying on the ones already provided by Panther
+* `PANTHER_CHROME_ARGUMENTS`: to customize `chromedriver` arguments. You need to set `PANTHER_NO_HEADLESS` to fully customize.
 
 ## Docker Integration
 

--- a/src/ProcessManager/ChromeManager.php
+++ b/src/ProcessManager/ChromeManager.php
@@ -90,6 +90,12 @@ final class ChromeManager implements BrowserManagerInterface
             // Running in Travis, disabling the sandbox mode
             $args[] = '--no-sandbox';
         }
+        
+        // Add custom arguments with PANTHER_CHROME_ARGUMENTS
+        if ($_SERVER['PANTHER_CHROME_ARGUMENTS'] ?? false) {
+            $arguments = explode(' ', $_SERVER['PANTHER_CHROME_ARGUMENTS']);
+            $args = array_merge($args, $arguments);
+        }
 
         return $args;
     }

--- a/src/ProcessManager/ChromeManager.php
+++ b/src/ProcessManager/ChromeManager.php
@@ -90,11 +90,11 @@ final class ChromeManager implements BrowserManagerInterface
             // Running in Travis, disabling the sandbox mode
             $args[] = '--no-sandbox';
         }
-        
+
         // Add custom arguments with PANTHER_CHROME_ARGUMENTS
         if ($_SERVER['PANTHER_CHROME_ARGUMENTS'] ?? false) {
-            $arguments = explode(' ', $_SERVER['PANTHER_CHROME_ARGUMENTS']);
-            $args = array_merge($args, $arguments);
+            $arguments = \explode(' ', $_SERVER['PANTHER_CHROME_ARGUMENTS']);
+            $args = \array_merge($args, $arguments);
         }
 
         return $args;

--- a/src/ProcessManager/ChromeManager.php
+++ b/src/ProcessManager/ChromeManager.php
@@ -93,8 +93,8 @@ final class ChromeManager implements BrowserManagerInterface
 
         // Add custom arguments with PANTHER_CHROME_ARGUMENTS
         if ($_SERVER['PANTHER_CHROME_ARGUMENTS'] ?? false) {
-            $arguments = \explode(' ', $_SERVER['PANTHER_CHROME_ARGUMENTS']);
-            $args = \array_merge($args, $arguments);
+            $arguments = explode(' ', $_SERVER['PANTHER_CHROME_ARGUMENTS']);
+            $args = array_merge($args, $arguments);
         }
 
         return $args;


### PR DESCRIPTION
I think It can be great to customize chromedriver arguments. By default, we don't see window (Not important but amazing for a concrete demo :)). We can disable headless with PANTHER_NO_HEADLESS but we lost the "--disable-gpu" arguments and it is important on Macbook Pro (But maybe for other device). I purpose to add a ENV variable where we can define all arguments we need. I want to precise that for use this ENV variable, we need to set PANTHER_NO_HEADLESS to 1 to keep default component behavior.