### PR TITLE
Bump min PHP version up to 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.2",
     "facebook/webdriver": "^1.5",
     "symfony/browser-kit": "^4.0",
     "symfony/polyfill-php72": "^1.9",


### PR DESCRIPTION
Fixes #39 - Panther uses PHP 7.2 language features such as object return type and should therefore require a min PHP version of 7.2