### PR TITLE
Ability to set a custom "google-chrome" binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ The following environment variables can be set to change some Panther behaviors:
 * `PANTHER_CHROME_ARGUMENTS`: to customize `chromedriver` arguments. You need to set `PANTHER_NO_HEADLESS` to fully customize.
 * `PANTHER_WEB_SERVER_PORT`: to change the web server's port (default to `9080`)
 * `PANTHER_WEB_SERVER_ROUTER`:  to use a web server router script which is run at the start of each HTTP request
+* `PANTHER_CHROME_BINARY`: to use another `google-chrome` binary
 
 ### Docker Integration
 

--- a/src/ProcessManager/ChromeManager.php
+++ b/src/ProcessManager/ChromeManager.php
@@ -54,7 +54,7 @@ final class ChromeManager implements BrowserManagerInterface
             $chromeOptions = new ChromeOptions();
             $chromeOptions->addArguments($this->arguments);
             $capabilities->setCapability(ChromeOptions::CAPABILITY, $chromeOptions);
-            if (isset($_SERVER['PANTHER_CHROME_BINARY']) {
+            if (isset($_SERVER['PANTHER_CHROME_BINARY'])) {
                 $chromeOptions->setBinary($_SERVER['PANTHER_CHROME_BINARY']);
             }
         }

--- a/src/ProcessManager/ChromeManager.php
+++ b/src/ProcessManager/ChromeManager.php
@@ -53,6 +53,7 @@ final class ChromeManager implements BrowserManagerInterface
         if ($this->arguments) {
             $chromeOptions = new ChromeOptions();
             $chromeOptions->addArguments($this->arguments);
+            $chromeOptions->setBinary(getenv('PANTHER_CHROME_BINARY') ?: '');
             $capabilities->setCapability(ChromeOptions::CAPABILITY, $chromeOptions);
         }
 

--- a/src/ProcessManager/ChromeManager.php
+++ b/src/ProcessManager/ChromeManager.php
@@ -53,8 +53,10 @@ final class ChromeManager implements BrowserManagerInterface
         if ($this->arguments) {
             $chromeOptions = new ChromeOptions();
             $chromeOptions->addArguments($this->arguments);
-            $chromeOptions->setBinary(getenv('PANTHER_CHROME_BINARY') ?: '');
             $capabilities->setCapability(ChromeOptions::CAPABILITY, $chromeOptions);
+            if (isset($_SERVER['PANTHER_CHROME_BINARY']) {
+                $chromeOptions->setBinary($_SERVER['PANTHER_CHROME_BINARY']);
+            }
         }
 
         return RemoteWebDriver::create($url, $capabilities);


### PR DESCRIPTION
I added the ability to set a custom Chrome binary by using "GOOGLE_CHROME_SHIM" environment variable.

You need it to be able to use Panther with Heroku (https://elements.heroku.com/buildpacks/heroku/heroku-buildpack-google-chrome)

Otherwise you'll have the "cannot find Chrome binary" error.