### PR TITLE
Add Client->refreshCrawler() method

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -157,6 +157,11 @@ final class Client extends BaseClient implements WebDriver
         return parent::submit($form, $values);
     }
 
+    public function refreshCrawler(): Crawler
+    {
+        return $this->crawler = $this->createCrawler();
+    }
+
     public function request(string $method, string $uri, array $parameters = [], array $files = [], array $server = [], string $content = null, bool $changeHistory = true): Crawler
     {
         if ('GET' !== $method) {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\Panther\Tests;
 
 use Facebook\WebDriver\Remote\RemoteWebElement;
 use Facebook\WebDriver\WebDriver;
+use Facebook\WebDriver\WebDriverExpectedCondition;
 use Symfony\Component\BrowserKit\Client as BrowserKitClient;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\BrowserKit\CookieJar as BrowserKitCookieJar;
@@ -56,6 +57,25 @@ class ClientTest extends TestCase
         if (Client::class === $type) {
             $this->assertInstanceOf(Crawler::class, $crawler);
         }
+    }
+
+    public function testRefreshCrawler(): void
+    {
+        $client = self::createPantherClient();
+
+        $crawler = $client->request('GET', '/js-redirect.html');
+        $linkCrawler = $crawler->selectLink('Redirect Link');
+
+        $this->assertSame('Redirect Link', $linkCrawler->text());
+
+        $client->click($linkCrawler->link());
+        $client->wait(5)->until(WebDriverExpectedCondition::titleIs('A basic page'));
+
+        $refreshedCrawler = $client->refreshCrawler();
+
+        $this->assertInstanceOf(Crawler::class, $refreshedCrawler);
+        $this->assertSame(self::$baseUri.'/basic.html', $refreshedCrawler->getUri());
+        $this->assertSame('Hello', $refreshedCrawler->filter('h1')->text());
     }
 
     /**

--- a/tests/fixtures/js-redirect.html
+++ b/tests/fixtures/js-redirect.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>JavaScript redirect page</title>
+    </head>
+    <body>
+        <h1>Hello</h1>
+        <a href="#" id="redirect-link">Redirect Link</a>
+    </body>
+
+    <script type="text/javascript">
+        document.querySelector('#redirect-link')
+            .addEventListener('click', function() {
+                onRedirectClick();
+            });
+
+        function onRedirectClick() {
+            window.setTimeout(function() {
+                window.location.href = 'basic.html';
+            }, 2000)
+        }
+    </script>
+</html>


### PR DESCRIPTION
WebDriver currently doesn't refresh the crawler component when a page uses deferred redirects through JavaScript. 

TestCase's would need access to a refreshed Crawler component when testing anything asynchronous like a login form that consumes an API endpoint.