### PR TITLE
Change default port to 9080

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ The following environment variables can be set to change some Panther behaviors:
 * `PANTHER_WEB_SERVER_DIR`: to change the project's document root (default to `public/`)
 * `PANTHER_CHROME_DRIVER_BINARY`: to use another `chromedriver` binary, instead of relying on the ones already provided by Panther
 * `PANTHER_CHROME_ARGUMENTS`: to customize `chromedriver` arguments. You need to set `PANTHER_NO_HEADLESS` to fully customize.
-* `PANTHER_WEB_SERVER_PORT`: to change the web server's port (default to `9000`)
+* `PANTHER_WEB_SERVER_PORT`: to change the web server's port (default to `9080`)
 * `PANTHER_WEB_SERVER_ROUTER`:  to use a web server router script which is run at the start of each HTTP request
 
 ## Docker Integration

--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -62,7 +62,7 @@ trait PantherTestCaseTrait
     protected static $defaultOptions = [
         'webServerDir' => __DIR__.'/../../../../public', // the Flex directory structure
         'hostname' => '127.0.0.1',
-        'port' => 9000,
+        'port' => 9080,
         'router' => '',
     ];
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -241,7 +241,7 @@ JS
      */
     public function testServerPort(callable $clientFactory): void
     {
-        $expectedPort = $_SERVER['PANTHER_WEB_SERVER_PORT'] ?? '9000';
+        $expectedPort = $_SERVER['PANTHER_WEB_SERVER_PORT'] ?? '9080';
         $client = $clientFactory();
         $this->assertEquals($expectedPort, \mb_substr(self::$baseUri, -4));
     }


### PR DESCRIPTION
Using 9000 as a default port is in conflit with the default Xdebug port.

>xdebug.remote_port
Type: integer, Default value: 9000
The port to which Xdebug tries to connect on the remote host. Port 9000 is the default for both the client and the bundled debugclient. As many clients use this port number, it is best to leave this setting unchanged.

https://xdebug.org/docs/all_settings