### PR TITLE
Client::waitFor() returns a crawler

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -16,7 +16,6 @@ namespace Symfony\Component\Panther;
 use Facebook\WebDriver\Exception\NoSuchElementException;
 use Facebook\WebDriver\Exception\TimeOutException;
 use Facebook\WebDriver\JavaScriptExecutor;
-use Facebook\WebDriver\Remote\RemoteWebElement;
 use Facebook\WebDriver\WebDriver;
 use Facebook\WebDriver\WebDriverBy;
 use Facebook\WebDriver\WebDriverCapabilities;
@@ -251,13 +250,15 @@ final class Client extends BaseClient implements WebDriver, JavaScriptExecutor
      * @throws NoSuchElementException
      * @throws TimeOutException
      *
-     * @return RemoteWebElement
+     * @return Crawler
      */
     public function waitFor(string $cssSelector, int $timeoutInSecond = 30, int $intervalInMillisecond = 250)
     {
-        return $this->wait($timeoutInSecond, $intervalInMillisecond)->until(
+        $this->wait($timeoutInSecond, $intervalInMillisecond)->until(
             WebDriverExpectedCondition::visibilityOfElementLocated(WebDriverBy::cssSelector($cssSelector))
         );
+
+        return $this->crawler = $this->createCrawler();
     }
 
     public function getWebDriver(): WebDriver

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Symfony\Component\Panther\Tests;
 
 use Facebook\WebDriver\JavaScriptExecutor;
-use Facebook\WebDriver\Remote\RemoteWebElement;
 use Facebook\WebDriver\WebDriver;
 use Facebook\WebDriver\WebDriverExpectedCondition;
 use Symfony\Component\BrowserKit\Client as BrowserKitClient;
@@ -45,7 +44,7 @@ class ClientTest extends TestCase
         $client = self::createPantherClient();
         $crawler = $client->request('GET', '/waitfor.html');
         $c = $client->waitFor('#hello');
-        $this->assertInstanceOf(RemoteWebElement::class, $c);
+        $this->assertInstanceOf(Crawler::class, $c);
         $this->assertSame('Hello', $crawler->filter('#hello')->text());
     }
 


### PR DESCRIPTION
In addition to #102, I think that `Client::waitFor()` should directly return an updated crawler.