### PR TITLE
Replace $_SERVER by $_ENV

### DIFF
--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -102,10 +102,10 @@ trait PantherTestCaseTrait
         }
 
         $options = [
-            'webServerDir' => $options['webServerDir'] ?? static::$webServerDir ?? $_SERVER['PANTHER_WEB_SERVER_DIR'] ?? self::$defaultOptions['webServerDir'],
+            'webServerDir' => $options['webServerDir'] ?? static::$webServerDir ?? getenv('PANTHER_WEB_SERVER_DIR') ?: self::$defaultOptions['webServerDir'],
             'hostname' => $options['webServerDir'] ?? self::$defaultOptions['hostname'],
-            'port' => (int) ($options['port'] ?? $_SERVER['PANTHER_WEB_SERVER_PORT'] ?? self::$defaultOptions['port']),
-            'router' => $options['router'] ?? $_SERVER['PANTHER_WEB_SERVER_ROUTER'] ?? self::$defaultOptions['router'],
+            'port' => (int) ($options['port'] ?? getenv('PANTHER_WEB_SERVER_PORT') ?: self::$defaultOptions['port']),
+            'router' => $options['router'] ?? getenv('PANTHER_WEB_SERVER_ROUTER') ?: self::$defaultOptions['router'],
         ];
 
         self::$webServerManager = new WebServerManager(...array_values($options));

--- a/src/ProcessManager/ChromeManager.php
+++ b/src/ProcessManager/ChromeManager.php
@@ -66,7 +66,7 @@ final class ChromeManager implements BrowserManagerInterface
 
     private function findChromeDriverBinary(): string
     {
-        if ($binary = $_SERVER['PANTHER_CHROME_DRIVER_BINARY'] ?? null) {
+        if ($binary = getenv('PANTHER_CHROME_DRIVER_BINARY')) {
             return $binary;
         }
 
@@ -83,17 +83,17 @@ final class ChromeManager implements BrowserManagerInterface
     private function getDefaultArguments(): array
     {
         // Enable the headless mode unless PANTHER_NO_HEADLESS is defined
-        $args = ($_SERVER['PANTHER_NO_HEADLESS'] ?? false) ? [] : ['--headless', 'window-size=1200,1100', '--disable-gpu'];
+        $args = getenv('PANTHER_NO_HEADLESS') ? [] : ['--headless', 'window-size=1200,1100', '--disable-gpu'];
 
         // Disable Chrome's sandbox if PANTHER_NO_SANDBOX is defined or if running in Travis
-        if ($_SERVER['PANTHER_NO_SANDBOX'] ?? $_SERVER['HAS_JOSH_K_SEAL_OF_APPROVAL'] ?? false) {
+        if (getenv('PANTHER_NO_SANDBOX') ?: getenv('HAS_JOSH_K_SEAL_OF_APPROVAL')) {
             // Running in Travis, disabling the sandbox mode
             $args[] = '--no-sandbox';
         }
 
         // Add custom arguments with PANTHER_CHROME_ARGUMENTS
-        if ($_SERVER['PANTHER_CHROME_ARGUMENTS'] ?? false) {
-            $arguments = explode(' ', $_SERVER['PANTHER_CHROME_ARGUMENTS']);
+        if (getenv('PANTHER_CHROME_ARGUMENTS')) {
+            $arguments = explode(' ', (string) getenv('PANTHER_CHROME_ARGUMENTS'));
             $args = array_merge($args, $arguments);
         }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -241,7 +241,7 @@ JS
      */
     public function testServerPort(callable $clientFactory): void
     {
-        $expectedPort = $_SERVER['PANTHER_WEB_SERVER_PORT'] ?? '9080';
+        $expectedPort = getenv('PANTHER_WEB_SERVER_PORT') ?: '9080';
         $client = $clientFactory();
         $this->assertEquals($expectedPort, \mb_substr(self::$baseUri, -4));
     }


### PR DESCRIPTION
PHPUnit internally uses `$_ENV` for the env vars. This, it is possible to edit env vars through the `phpunit.xml.dist `:

```xml
<phpunit>
    <php>
        <env name="PANTHER_WEB_SERVER_ROUTER" value="router.php"/>
    </php>
</phpunit>
```
cf https://phpunit.readthedocs.io/en/7.3/configuration.html?highlight=env#setting-php-ini-settings-constants-and-global-variables