### PR TITLE
Pause on fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,6 @@ install:
     fi
 
 script:
-  - phpunit
+  - vendor/bin/phpunit
   - if [[ $lint = '1' ]]; then php php-cs-fixer.phar fix --dry-run --diff --no-ansi; fi
   - if [[ $lint = '1' ]]; then php phpstan.phar analyse src tests --level=6; fi

--- a/README.md
+++ b/README.md
@@ -130,6 +130,20 @@ class E2eTest extends PantherTestCase
 }
 ```
 
+### Interactive Mode
+
+Panther can make a pause in your tests suites after a failure.
+It is a break time really appreciated for investigating the problem through the web browser.
+For enabling this mode, you need the `--debug` PHPUnit option without the headless mode:
+
+    $ export PANTHER_NO_HEADLESS=1
+    $ phpunit --debug
+    
+    Test 'App\AdminTest::testLogin' started
+    Error: something is wrong.
+    
+    Press enter to continue...
+
 ## Features
 
 Unlike testing and web scraping libraries you're used to, Panther:

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
   "require-dev": {
     "guzzlehttp/guzzle": "^6.3",
     "fabpot/goutte": "^3.2.3",
-    "phpunit/phpunit": "^7.0",
+    "phpunit/phpunit": "^7.3",
     "symfony/css-selector": "^3.4 || ^4.0",
     "symfony/framework-bundle": "^3.4 || ^4.0"
   }

--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -114,6 +114,11 @@ trait PantherTestCaseTrait
         self::$baseUri = sprintf('http://%s:%s', $options['hostname'], $options['port']);
     }
 
+    public static function isWebServerStarted()
+    {
+        return self::$webServerManager->isStarted();
+    }
+
     /**
      * @param array $options       see {@see $defaultOptions}
      * @param array $kernelOptions

--- a/src/ProcessManager/WebServerManager.php
+++ b/src/ProcessManager/WebServerManager.php
@@ -79,4 +79,9 @@ final class WebServerManager
     {
         $this->process->stop();
     }
+
+    public function isStarted()
+    {
+        return $this->process->isStarted();
+    }
 }

--- a/src/ServerExtension.php
+++ b/src/ServerExtension.php
@@ -14,12 +14,14 @@ declare(strict_types=1);
 namespace Symfony\Component\Panther;
 
 use PHPUnit\Runner\AfterLastTestHook;
+use PHPUnit\Runner\AfterTestErrorHook;
+use PHPUnit\Runner\AfterTestFailureHook;
 use PHPUnit\Runner\BeforeFirstTestHook;
 
 /**
  *  @author Dany Maillard <danymaillard93b@gmail.com>
  */
-final class ServerExtension implements BeforeFirstTestHook, AfterLastTestHook
+final class ServerExtension implements BeforeFirstTestHook, AfterLastTestHook, AfterTestErrorHook, AfterTestFailureHook
 {
     use ServerTrait;
 
@@ -31,5 +33,15 @@ final class ServerExtension implements BeforeFirstTestHook, AfterLastTestHook
     public function executeAfterLastTest(): void
     {
         $this->stopWebServer();
+    }
+
+    public function executeAfterTestError(string $test, string $message, float $time): void
+    {
+        $this->pause(sprintf('Error: %s', $message));
+    }
+
+    public function executeAfterTestFailure(string $test, string $message, float $time): void
+    {
+        $this->pause(sprintf('Failure: %s', $message));
     }
 }

--- a/src/ServerListener.php
+++ b/src/ServerListener.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Symfony\Component\Panther;
 
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestListener;
 use PHPUnit\Framework\TestListenerDefaultImplementation;
 use PHPUnit\Framework\TestSuite;
@@ -30,5 +32,15 @@ final class ServerListener implements TestListener
     public function endTestSuite(TestSuite $suite): void
     {
         $this->stopWebServer();
+    }
+
+    public function addError(Test $test, \Throwable $t, float $time): void
+    {
+        $this->pause(sprintf('Error: %s', $t->getMessage()));
+    }
+
+    public function addFailure(Test $test, AssertionFailedError $e, float $time): void
+    {
+        $this->pause(sprintf('Failure: %s', $e->getMessage()));
     }
 }

--- a/src/ServerTrait.php
+++ b/src/ServerTrait.php
@@ -20,6 +20,8 @@ namespace Symfony\Component\Panther;
  */
 trait ServerTrait
 {
+    public $testing = false;
+
     private function keepServerOnTeardown(): void
     {
         PantherTestCase::$stopServerOnTeardown = false;
@@ -28,5 +30,18 @@ trait ServerTrait
     private function stopWebServer(): void
     {
         PantherTestCase::stopWebServer();
+    }
+
+    private function pause($message): void
+    {
+        if (PantherTestCase::isWebServerStarted()
+            && \in_array('--debug', $_SERVER['argv'], true)
+            && $_SERVER['PANTHER_NO_HEADLESS'] ?? false
+        ) {
+            echo "$message\n\nPress enter to continue...";
+            if (!$this->testing) {
+                fgets(STDIN);
+            }
+        }
     }
 }

--- a/tests/ServerExtensionTest.php
+++ b/tests/ServerExtensionTest.php
@@ -25,12 +25,48 @@ class ServerExtensionTest extends TestCase
 
     public function testStartAndStop(): void
     {
-        $listener = new ServerExtension();
+        $extension = new ServerExtension();
 
-        $listener->executeBeforeFirstTest();
+        $extension->executeBeforeFirstTest();
         static::assertFalse(PantherTestCase::$stopServerOnTeardown);
 
-        $listener->executeAfterLastTest();
+        $extension->executeAfterLastTest();
         static::assertNull(PantherTestCase::$webServerManager);
+    }
+
+    /**
+     * @dataProvider provideTestPauseOnFailure
+     */
+    public function testPauseOnFailure(string $method, string $expected): void
+    {
+        $extension = new ServerExtension();
+        $extension->testing = true;
+
+        // stores current state
+        $argv = $_SERVER['argv'];
+        $noHeadless = $_SERVER['PANTHER_NO_HEADLESS'] ?? false;
+
+        self::startWebServer();
+        $_SERVER['argv'][] = '--debug';
+        $_SERVER['PANTHER_NO_HEADLESS'] = 1;
+
+        $extension->{$method}('test', 'message', 0);
+        $this->expectOutputString($expected);
+
+        // restores previous state
+        $_SERVER['argv'] = $argv;
+        if (false === $noHeadless) {
+            unset($_SERVER['PANTHER_NO_HEADLESS']);
+        } else {
+            $_SERVER['PANTHER_NO_HEADLESS'] = $noHeadless;
+        }
+    }
+
+    public function provideTestPauseOnFailure()
+    {
+        return [
+            ['executeAfterTestError', "Error: message\n\nPress enter to continue..."],
+            ['executeAfterTestFailure', "Failure: message\n\nPress enter to continue..."],
+        ];
     }
 }

--- a/tests/ServerListenerTest.php
+++ b/tests/ServerListenerTest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Symfony\Component\Panther\Tests;
 
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestSuite;
 use Symfony\Component\Panther\PantherTestCase;
 use Symfony\Component\Panther\ServerListener;
@@ -34,5 +36,41 @@ class ServerListenerTest extends TestCase
 
         $listener->endTestSuite($testSuite);
         static::assertNull(PantherTestCase::$webServerManager);
+    }
+
+    /**
+     * @dataProvider provideTestPauseOnFailure
+     */
+    public function testPauseOnFailure(string $method, string $expected): void
+    {
+        $listener = new ServerListener();
+        $listener->testing = true;
+
+        // stores current state
+        $argv = $_SERVER['argv'];
+        $noHeadless = $_SERVER['PANTHER_NO_HEADLESS'] ?? false;
+
+        self::startWebServer();
+        $_SERVER['argv'][] = '--debug';
+        $_SERVER['PANTHER_NO_HEADLESS'] = 1;
+
+        $listener->{$method}($this->getMockForAbstractClass(Test::class), new AssertionFailedError('message'), 0);
+        $this->expectOutputString($expected);
+
+        // restores previous state
+        $_SERVER['argv'] = $argv;
+        if (false === $noHeadless) {
+            unset($_SERVER['PANTHER_NO_HEADLESS']);
+        } else {
+            $_SERVER['PANTHER_NO_HEADLESS'] = $noHeadless;
+        }
+    }
+
+    public function provideTestPauseOnFailure()
+    {
+        return [
+            ['addError', "Error: message\n\nPress enter to continue..."],
+            ['addFailure', "Failure: message\n\nPress enter to continue..."],
+        ];
     }
 }


### PR DESCRIPTION
Currently, it's a little bit boring when a failure/error occurred because there is no way for investigating it at the moment through the browser because it is killed. This PR add an interactive mode by making a pause after every failure/error.

```
➜ PANTHER_NO_HEADLESS=1 vendor/bin/phpunit --debug

Test 'App\AdminTest::testAdmin' started
Error: ko

Press enter to continue...
```

This interactive mode works when the web server is started, the debug option used and the no headless env var set.