### PR TITLE
The minimal requirement for PHP is 7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ addons:
   chrome: stable
 
 php:
-  - 7.2
+  - 7.1
 
 script:
   - phpunit
@@ -267,7 +267,7 @@ install:
   - ps: Set-Service wuauserv -StartupType Manual
   - cinst -y php composer googlechrome
   - refreshenv
-  - cd c:\tools\php72
+  - cd c:\tools\php71
   - copy php.ini-production php.ini /Y
   - echo date.timezone="UTC" >> php.ini
   - echo extension_dir=ext >> php.ini

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ install:
   - ps: Set-Service wuauserv -StartupType Manual
   - cinst -y php composer googlechrome
   - refreshenv
-  - cd c:\tools\php71
+  - cd c:\tools\php72
   - copy php.ini-production php.ini /Y
   - echo date.timezone="UTC" >> php.ini
   - echo extension_dir=ext >> php.ini

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ addons:
 
 php:
   - 7.1
+  - 7.2
 
 script:
   - phpunit


### PR DESCRIPTION
Since we've been able to downgrade the PHP requirements, Travis/AppVeyor configurations must be updated.