### PR TITLE
Added a warning about the `unzip` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Use [Composer](https://getcomposer.org/) to install Panther in your project. You
     
     composer req --dev symfony/panther
 
-**Warning: make sure you have `unzip` installed on your computer. If you don't, you may have strange issues due to a PHP's zip extension not preserving the permissions of binaries.**
+**Warning:** The `unzip` command must be installed or you will encounter an error similar to `RuntimeException: sh: 1: exec: /app/vendor/symfony/panther/src/ProcessManager/../../chromedriver-bin/chromedriver_linux64: Permission denied` (or `chromedriver_linux64: not found).
+The underlying reason is that PHP's `ZipArchive` doesn't preserve UNIX executable permissions.
 
 ## Basic Usage
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Use [Composer](https://getcomposer.org/) to install Panther in your project. You
     
     composer req --dev symfony/panther
 
+**Warning: make sure you have `unzip` installed on your computer. If you don't, you may have strange issues due to a PHP's zip extension not preserving the permissions of binaries.**
+
 ## Basic Usage
 
 ```php

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Use [Composer](https://getcomposer.org/) to install Panther in your project. You
     
     composer req --dev symfony/panther
 
-**Warning:** The `unzip` command must be installed or you will encounter an error similar to `RuntimeException: sh: 1: exec: /app/vendor/symfony/panther/src/ProcessManager/../../chromedriver-bin/chromedriver_linux64: Permission denied` (or `chromedriver_linux64: not found).
+**Warning:** On \*nix systems, the `unzip` command must be installed or you will encounter an error similar to `RuntimeException: sh: 1: exec: /app/vendor/symfony/panther/src/ProcessManager/../../chromedriver-bin/chromedriver_linux64: Permission denied` (or `chromedriver_linux64: not found).
 The underlying reason is that PHP's `ZipArchive` doesn't preserve UNIX executable permissions.
 
 ## Basic Usage

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Use [Composer](https://getcomposer.org/) to install Panther in your project. You
     
     composer req --dev symfony/panther
 
-**Warning:** On \*nix systems, the `unzip` command must be installed or you will encounter an error similar to `RuntimeException: sh: 1: exec: /app/vendor/symfony/panther/src/ProcessManager/../../chromedriver-bin/chromedriver_linux64: Permission denied` (or `chromedriver_linux64: not found).
+**Warning:** On \*nix systems, the `unzip` command must be installed or you will encounter an error similar to `RuntimeException: sh: 1: exec: /app/vendor/symfony/panther/src/ProcessManager/../../chromedriver-bin/chromedriver_linux64: Permission denied` (or `chromedriver_linux64: not found`).
 The underlying reason is that PHP's `ZipArchive` doesn't preserve UNIX executable permissions.
 
 ## Basic Usage


### PR DESCRIPTION
This pull request adds a warning to the README about the `unzip` command that must be installed on the computer, especially on Linux systems, as proposed in issue #54.