### PR TITLE
Fix E2eTest example to use `html()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ class E2eTest extends PantherTestCase
         $client = static::createPantherClient(); // Your app is automatically started using the built-in web server
         $crawler = $client->request('GET', '/mypage');
 
-        $this->assertContains('My Title', $crawler->filter('title')->text()); // You can use any PHPUnit assertion
+        $this->assertContains('My Title', $crawler->filter('title')->html()); // You can use any PHPUnit assertion
     }
 }
 ```


### PR DESCRIPTION
In `E2eTest` Example, `text()` method was used with `title` - which is hidden text - so the assertion below will always fail:
`$this->assertContains('My Title', $crawler->filter('title')->text());`
as `text()` method will return empty string, the statement should be updated to use `html()` method as mentioned in **Hidden Text** section, to be like:
`$this->assertContains('My Title', $crawler->filter('title')->html());`