### PR TITLE
Pass the port number to ChromeDriver

### DIFF
--- a/src/ProcessManager/ChromeManager.php
+++ b/src/ProcessManager/ChromeManager.php
@@ -32,9 +32,9 @@ final class ChromeManager implements BrowserManagerInterface
 
     public function __construct(?string $chromeDriverBinary = null, ?array $arguments = null, array $options = [])
     {
-        $this->process = new Process([$chromeDriverBinary ?: $this->findChromeDriverBinary()], null, null, null, null);
-        $this->arguments = $arguments ?? $this->getDefaultArguments();
         $this->options = array_merge($this->getDefaultOptions(), $options);
+        $this->process = new Process([$chromeDriverBinary ?: $this->findChromeDriverBinary(), '--port='.$this->options['port']], null, null, null, null);
+        $this->arguments = $arguments ?? $this->getDefaultArguments();
     }
 
     /**

--- a/tests/ProcessManager/ChromeManagerTest.php
+++ b/tests/ProcessManager/ChromeManagerTest.php
@@ -45,4 +45,27 @@ class ChromeManagerTest extends TestCase
             $driver1->quit();
         }
     }
+
+    public function testNonDefaultPort()
+    {
+        $manager = new ChromeManager(null, null, ['port' => 9516]);
+        $client = $manager->start();
+        $this->assertNotEmpty($client->getCurrentURL());
+        $manager->quit();
+    }
+
+    public function testMultipleInstances()
+    {
+        $driver1 = new ChromeManager();
+        $client1 = $driver1->start();
+
+        $driver2 = new ChromeManager(null, null, ['port' => 9516]);
+        $client2 = $driver2->start();
+
+        $this->assertNotEmpty($client1->getCurrentURL());
+        $this->assertNotEmpty($client2->getCurrentURL());
+
+        $driver1->quit();
+        $driver2->quit();
+    }
 }


### PR DESCRIPTION
This allows you to specify a different port number that the `ChromeDriver` should listen to and that the `ChromeManager` should try connecting to if you know the default 9515 isn't available or if you want to run multiple instances on one machine.

Before this patch, if you passed a port number to `ChromeManager` it would never successfully connect to the `ChromeDriver` since the driver was always listening to the default port 9515.