### PR TITLE
Add sexy mouse API

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -33,6 +33,7 @@ use Symfony\Component\Panther\DomCrawler\Link as PantherLink;
 use Symfony\Component\Panther\ProcessManager\BrowserManagerInterface;
 use Symfony\Component\Panther\ProcessManager\ChromeManager;
 use Symfony\Component\Panther\ProcessManager\SeleniumManager;
+use Symfony\Component\Panther\WebDriver\WebDriverMouse;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -425,12 +426,12 @@ final class Client extends BaseClient implements WebDriver, JavaScriptExecutor, 
         return $this->webDriver->getKeyboard();
     }
 
-    public function getMouse()
+    public function getMouse(): WebDriverMouse
     {
         if (!$this->webDriver instanceof WebDriverHasInputDevices) {
             throw new \RuntimeException(sprintf('"%s" does not implement "%s".', \get_class($this->webDriver), WebDriverHasInputDevices::class));
         }
 
-        return $this->webDriver->getMouse();
+        return new WebDriverMouse($this->webDriver->getMouse(), $this);
     }
 }

--- a/src/WebDriver/WebDriverMouse.php
+++ b/src/WebDriver/WebDriverMouse.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of the Panther project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Panther\WebDriver;
+
+use Facebook\WebDriver\Interactions\Internal\WebDriverCoordinates;
+use Facebook\WebDriver\Internal\WebDriverLocatable;
+use Facebook\WebDriver\WebDriverMouse as BaseWebDriverMouse;
+use Symfony\Component\Panther\Client;
+
+/**
+ * @author Dany Maillard <danymaillard93b@gmail.com>
+ */
+final class WebDriverMouse implements BaseWebDriverMouse
+{
+    private $mouse;
+    private $client;
+
+    public function __construct(BaseWebDriverMouse $mouse, Client $client)
+    {
+        $this->mouse = $mouse;
+        $this->client = $client;
+    }
+
+    public function click(WebDriverCoordinates $where): self
+    {
+        $this->mouse->click($where);
+
+        return $this;
+    }
+
+    public function clickTo($cssSelector): self
+    {
+        return $this->click($this->toCoordinates($cssSelector));
+    }
+
+    public function contextClick(WebDriverCoordinates $where): self
+    {
+        $this->mouse->contextClick($where);
+
+        return $this;
+    }
+
+    public function contextClickTo($cssSelector): self
+    {
+        return $this->contextClick($this->toCoordinates($cssSelector));
+    }
+
+    public function doubleClick(WebDriverCoordinates $where): self
+    {
+        $this->mouse->doubleClick($where);
+
+        return $this;
+    }
+
+    public function doubleClickTo($cssSelector): self
+    {
+        return $this->doubleClick($this->toCoordinates($cssSelector));
+    }
+
+    public function mouseDown(WebDriverCoordinates $where): self
+    {
+        $this->mouse->mouseDown($where);
+
+        return $this;
+    }
+
+    public function mouseDownTo($cssSelector): self
+    {
+        return $this->mouseDown($this->toCoordinates($cssSelector));
+    }
+
+    public function mouseMove(WebDriverCoordinates $where, $xOffset = null, $yOffset = null): self
+    {
+        $this->mouse->mouseMove($where, $xOffset, $yOffset);
+
+        return $this;
+    }
+
+    public function mouseMoveTo($cssSelector, $xOffset = null, $yOffset = null): self
+    {
+        return $this->mouseMove($this->toCoordinates($cssSelector), $xOffset, $yOffset);
+    }
+
+    public function mouseUp(WebDriverCoordinates $where): self
+    {
+        $this->mouse->mouseUp($where);
+
+        return $this;
+    }
+
+    public function mouseUpTo($cssSelector): self
+    {
+        return $this->mouseUp($this->toCoordinates($cssSelector));
+    }
+
+    private function toCoordinates($cssSelector): WebDriverCoordinates
+    {
+        $element = $this->client->getCrawler()->filter($cssSelector)->getElement(0);
+
+        if (!$element instanceof WebDriverLocatable) {
+            throw new \RuntimeException(sprintf('The element of "%s" CSS selector does not implement "%s".', $cssSelector, WebDriverLocatable::class));
+        }
+
+        return $element->getCoordinates();
+    }
+}

--- a/tests/WebDriver/WebDriverMouseTest.php
+++ b/tests/WebDriver/WebDriverMouseTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Panther project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Panther\Tests\WebDriver;
+
+use Symfony\Component\Panther\Tests\TestCase;
+
+/**
+ * @author Dany Maillard <danymaillard93b@gmail.com>
+ */
+class WebDriverMouseTest extends TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        self::createPantherClient()->request('GET', self::$baseUri.'/mouse.html');
+    }
+
+    /**
+     * @dataProvider provide
+     */
+    public function test(string $method, string $cssSelector, string $result)
+    {
+        $client = self::createPantherClient();
+
+        $client->getMouse()->{$method}($cssSelector);
+        $this->assertEquals($result, $client->getCrawler()->filter('#result')->text());
+    }
+
+    public function provide()
+    {
+        return [
+            ['clickTo', '#mouse', 'click'],
+            ['doubleClickTo', '#mouse', 'dblclick'],
+            ['contextClickTo', '#mouse', 'contextmenu'],
+            ['mouseDownTo', '#mouse', 'mousedown'],
+            ['mouseMoveTo', '#mouse', 'mousemove'],
+            ['mouseUpTo', '#mouse-up', 'mouseup'],
+        ];
+    }
+}

--- a/tests/fixtures/mouse.html
+++ b/tests/fixtures/mouse.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>Mouse page</title>
+    </head>
+    <body>
+        <button id="mouse">Mouse me !</button>
+        <button id="mouse-up" onmouseup="callback(event)">Mouse up me !</button>
+        <p id="result"></p>
+    </body>
+
+    <script type="text/javascript">
+        var mouse = document.querySelector('#mouse');
+        var result = document.querySelector('#result');
+        mouse.addEventListener('click', callback);
+        mouse.addEventListener('dblclick', callback);
+        mouse.addEventListener('contextmenu', callback);
+        mouse.addEventListener('mousedown', callback);
+        mouse.addEventListener('mousemove', callback);
+        function callback (e) {
+            result.innerHTML = e.type;
+        }
+    </script>
+</html>


### PR DESCRIPTION
Using the mouse API is boring, e.g.:

```php
$client->getMouse()->mouseMove(
    $client->getCrawler()->filter('#my-element')->getElement(0)->getCoordinates()
);
```

This PR creates some helpful methods like:

```php
$client->getMouse()->mouseMoveTo($cssSelector = '#my-element');
```

cf https://github.com/symfony/panther/pull/117#issuecomment-427752018