### PR TITLE
Fix issue #118

### DIFF
--- a/src/ProcessManager/WebServerReadinessProbeTrait.php
+++ b/src/ProcessManager/WebServerReadinessProbeTrait.php
@@ -42,7 +42,7 @@ trait WebServerReadinessProbeTrait
             'ignore_errors' => $ignoreErrors,
             'protocol_version' => '1.1',
             'header' => ['Connection: close'],
-            'timeout' => 1,
+            'timeout' => 5,
         ]]);
 
         while (Process::STATUS_STARTED !== ($status = $process->getStatus()) || false === @file_get_contents($url, false, $context)) {


### PR DESCRIPTION
When running the server on Docker, `@file_get_contents($url, false, $context)` in `WebServerReadinessProbeTrait.php` always returns false because of the timeout in `$context` which is too low.
Because of that, the method `waitUntilReady` is stuck in an endless while loop.

Increasing the timeout from 1 to 5 seems to solve the problem.