### PR TITLE
Compatible with PHPUnit 8.0

### DIFF
--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -67,7 +67,7 @@ trait PantherTestCaseTrait
         'external_base_uri' => null,
     ];
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         if (self::$stopServerOnTeardown) {
             static::stopWebServer();

--- a/tests/ServerExtensionTest.php
+++ b/tests/ServerExtensionTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Panther\ServerExtension;
 
 class ServerExtensionTest extends TestCase
 {
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         PantherTestCase::$stopServerOnTeardown = true;
     }

--- a/tests/ServerListenerTest.php
+++ b/tests/ServerListenerTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Panther\ServerListener;
 
 class ServerListenerTest extends TestCase
 {
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         PantherTestCase::$stopServerOnTeardown = true;
     }

--- a/tests/WebDriver/WebDriverMouseTest.php
+++ b/tests/WebDriver/WebDriverMouseTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Panther\Tests\TestCase;
  */
 class WebDriverMouseTest extends TestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::createPantherClient()->request('GET', self::$baseUri.'/mouse.html');
     }


### PR DESCRIPTION
The latest version (8.0) of PHPUnit requires a return type void on tear down and setup functions.

https://github.com/sebastianbergmann/phpunit/blob/master/src/Framework/TestCase.php#L401

This is just a start to make Panther compatible with 8.0.