### PR TITLE
Added readinessPath to use custom path for server readiness detection

### DIFF
--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -65,6 +65,7 @@ trait PantherTestCaseTrait
         'port' => 9080,
         'router' => '',
         'external_base_uri' => null,
+        'readinessPath' => '',
     ];
 
     public static function tearDownAfterClass(): void
@@ -113,6 +114,7 @@ trait PantherTestCaseTrait
             'hostname' => $options['hostname'] ?? self::$defaultOptions['hostname'],
             'port' => (int) ($options['port'] ?? $_SERVER['PANTHER_WEB_SERVER_PORT'] ?? self::$defaultOptions['port']),
             'router' => $options['router'] ?? $_SERVER['PANTHER_WEB_SERVER_ROUTER'] ?? self::$defaultOptions['router'],
+            'readinessPath' => $options['readinessPath'] ?? $_SERVER['PANTHER_READINESS_PATH'] ?? self::$defaultOptions['readinessPath'],
         ];
 
         self::$webServerManager = new WebServerManager(...array_values($options));

--- a/src/ProcessManager/WebServerManager.php
+++ b/src/ProcessManager/WebServerManager.php
@@ -25,6 +25,7 @@ final class WebServerManager
 
     private $hostname;
     private $port;
+    private $readinessPath;
 
     /**
      * @var Process
@@ -34,10 +35,11 @@ final class WebServerManager
     /**
      * @throws \RuntimeException
      */
-    public function __construct(string $documentRoot, string $hostname, int $port, string $router = '')
+    public function __construct(string $documentRoot, string $hostname, int $port, string $router = '', string $readinessPath = '')
     {
         $this->hostname = $hostname;
         $this->port = $port;
+        $this->readinessPath = $readinessPath;
 
         $finder = new PhpExecutableFinder();
         if (false === $binary = $finder->find(false)) {
@@ -69,7 +71,13 @@ final class WebServerManager
         $this->checkPortAvailable($this->hostname, $this->port);
         $this->process->start();
 
-        $this->waitUntilReady($this->process, "http://$this->hostname:$this->port", true);
+        $url = "http://$this->hostname:$this->port";
+
+        if ($this->readinessPath) {
+            $url .= $this->readinessPath;
+        }
+
+        $this->waitUntilReady($this->process, $url, true);
     }
 
     /**


### PR DESCRIPTION
Hello,

I have a use case where my app is behind a security firewall that redirects anonymous users to Google's oauth page. In that case Panther fails to detect that the web server is up.

Here's a proposal to add a setting that allows custom path for readiness check. For instance you could do this : 

```php
$client = static::createPantherClient([
    'readinessPath' => '/ping'
]);

$client->getCookieJar()->set(new Cookie('jwt_token', $this->getTestToken()));
$client->request('GET', '/dashboard');
// [...]
```

And that would check `http://127.0.0.1:48008/ping` instead of `http://127.0.0.1:48008/`