### PR TITLE
Ensure same behavior of ChoiceFormField::getValue as in goutte client

### DIFF
--- a/src/DomCrawler/Field/ChoiceFormField.php
+++ b/src/DomCrawler/Field/ChoiceFormField.php
@@ -37,6 +37,10 @@ final class ChoiceFormField extends BaseChoiceFormField
 
     public function hasValue()
     {
+        if (\count($this->selector->getAllSelectedOptions())) {
+            return true;
+        }
+
         return $this->element->isSelected();
     }
 
@@ -73,6 +77,35 @@ final class ChoiceFormField extends BaseChoiceFormField
         }
 
         $this->setValue(false);
+    }
+
+    public function getValue()
+    {
+        $type = $this->element->getAttribute('type');
+
+        if (!$this->hasValue()) {
+            return $this->isMultiple() && 'checkbox' !== $type ? [] : null;
+        }
+
+        if ($this->isMultiple()) {
+            $value = [];
+            foreach ($this->selector->getAllSelectedOptions() as $selectedOption) {
+                if ($selectedOption->isSelected()) {
+                    $value[] = $selectedOption->getAttribute('value');
+                }
+            }
+
+            $count = \count($value);
+            if (1 === $count && 'checkbox' === $type) {
+                return \current($value);
+            }
+
+            return $value;
+        } elseif (\count($this->selector->getAllSelectedOptions())) {
+            return $this->selector->getFirstSelectedOption()->getAttribute('value');
+        }
+
+        return $this->element->getAttribute('value');
     }
 
     /**

--- a/tests/DomCrawler/Field/ChoiceFormFieldTest.php
+++ b/tests/DomCrawler/Field/ChoiceFormFieldTest.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ * This file is part of the Panther project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Panther\Tests\DomCrawler\Field;
+
+use Goutte\Client;
+use Symfony\Component\DomCrawler\Field\ChoiceFormField;
+use Symfony\Component\Panther\Tests\TestCase;
+
+/**
+ * @author Robert Freigang <robertfreigang@gmx.de>
+ */
+class ChoiceFormFieldTest extends TestCase
+{
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testGetValueFromSelectIfOneIsSelected(callable $clientFactory)
+    {
+        $crawler = $this->request($clientFactory, '/choice-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var ChoiceFormField */
+        $field = $form['select_selected_one'];
+        $this->assertInstanceOf(ChoiceFormField::class, $field);
+        $this->assertSame('20', $field->getValue());
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testGetValueFromSelectIfNoneIsSelected(callable $clientFactory)
+    {
+        $crawler = $this->request($clientFactory, '/choice-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var ChoiceFormField */
+        $field = $form['select_selected_none'];
+        $this->assertInstanceOf(ChoiceFormField::class, $field);
+        $this->assertSame('', $field->getValue());
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testGetValueFromSelectMultipleIfOneIsSelected(callable $clientFactory)
+    {
+        $crawler = $this->request($clientFactory, '/choice-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var ChoiceFormField */
+        $field = $form['select_multiple_selected_one'];
+        $this->assertInstanceOf(ChoiceFormField::class, $field);
+        $this->assertSame(['20'], $field->getValue());
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testGetValueFromSelectMultipleIfMultipleIsSelected(callable $clientFactory)
+    {
+        $crawler = $this->request($clientFactory, '/choice-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var ChoiceFormField */
+        $field = $form['select_multiple_selected_multiple'];
+        $this->assertInstanceOf(ChoiceFormField::class, $field);
+        $this->assertSame(['20', '30'], $field->getValue());
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testGetValueFromSelectMultipleIfNoneIsSelected(callable $clientFactory)
+    {
+        $crawler = $this->request($clientFactory, '/choice-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var ChoiceFormField */
+        $field = $form['select_multiple_selected_none'];
+        $this->assertInstanceOf(ChoiceFormField::class, $field);
+        $this->assertSame([], $field->getValue());
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testGetValueFromRadioIfSelected(callable $clientFactory)
+    {
+        $crawler = $this->request($clientFactory, '/choice-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var ChoiceFormField */
+        $field = $form['radio_checked'];
+        $this->assertInstanceOf(ChoiceFormField::class, $field);
+        $this->assertSame('i_am_checked', $field->getValue());
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testGetValueFromRadioIfNoneIsChecked(callable $clientFactory)
+    {
+        $crawler = $this->request($clientFactory, '/choice-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var ChoiceFormField */
+        $field = $form['radio_non_checked'];
+        $this->assertInstanceOf(ChoiceFormField::class, $field);
+        $this->assertNull($field->getValue());
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testGetValueFromCheckboxIfChecked(callable $clientFactory)
+    {
+        $crawler = $this->request($clientFactory, '/choice-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var ChoiceFormField */
+        $field = $form['checkbox_checked'];
+        $this->assertInstanceOf(ChoiceFormField::class, $field);
+        $this->assertSame('i_am_checked', $field->getValue());
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testGetValueFromCheckboxIfMultipleAreChecked(callable $clientFactory, string $type)
+    {
+        $crawler = $this->request($clientFactory, '/choice-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var ChoiceFormField */
+        $field = $form['checkbox_multiple_checked'];
+        $this->assertInstanceOf(ChoiceFormField::class, $field);
+        // we need this one! but it's not working in goutte
+        if (Client::class === $type) {
+            $this->markTestSkipped('Goutte client only returns one value. Maybe a bug in goutte?');
+        }
+        $this->assertSame(['checked_one', 'checked_two'], $field->getValue());
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testGetValueFromCheckboxIfNoneIsChecked(callable $clientFactory)
+    {
+        $crawler = $this->request($clientFactory, '/choice-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var ChoiceFormField */
+        $field = $form['checkbox_non_checked'];
+        $this->assertInstanceOf(ChoiceFormField::class, $field);
+        $this->assertNull($field->getValue());
+    }
+}

--- a/tests/fixtures/choice-form-field.html
+++ b/tests/fixtures/choice-form-field.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Form with ChoiceFormField</title>
+    <style>
+        label, .field {
+            border: 1px solid lightgrey;
+            display: block;
+        }
+    </style>
+</head>
+<body>
+<form method="post">
+
+    <label class="field">
+        select_selected_none
+        <select name="select_selected_none">
+            <option disabled selected value> -- select an option -- </option>
+            <option value="10">ten</option>
+            <option value="20">twenty</option>
+            <option value="30">thirty</option>
+        </select>
+    </label>
+
+    <label class="field">
+        select_selected_one
+        <select name="select_selected_one">
+            <option value="10">ten</option>
+            <option value="20" selected>twenty</option>
+            <option value="30">thirty</option>
+        </select>
+    </label>
+
+    <label class="field">
+        select_multiple_selected_one
+        <select name="select_multiple_selected_one" multiple="multiple">
+            <option value="10">ten</option>
+            <option value="20" selected>twenty</option>
+            <option value="30">thirty</option>
+        </select>
+    </label>
+
+
+    <label class="field">
+        select_multiple_selected_multiple
+        <select name="select_multiple_selected_multiple" multiple="multiple">
+            <option value="10">ten</option>
+            <option value="20" selected>twenty</option>
+            <option value="30" selected>thirty</option>
+        </select>
+    </label>
+
+    <label class="field">
+        select_multiple_selected_none
+        <select name="select_multiple_selected_none" multiple="multiple">
+            <option value="10">ten</option>
+            <option value="20">twenty</option>
+            <option value="30">thirty</option>
+        </select>
+    </label>
+
+    <div class="field">
+        radio_checked
+        <span><input type="radio" name="radio_checked" value="i_am_not_checked" />i_am_not_checked</span>
+        <span><input type="radio" name="radio_checked" value="i_am_checked" checked="checked" />i_am_checked</span>
+    </div>
+
+    <div class="field">
+        radio_non_checked
+        <span><input type="radio" name="radio_non_checked" value="not_checked_one" />not_checked_one</span>
+        <span><input type="radio" name="radio_non_checked" value="not_checked_two" />not_checked_two</span>
+    </div>
+
+    <div class="field">
+        checkbox_checked
+        <input type="checkbox" name="checkbox_checked" value="i_am_not_checked"/>
+        <input type="checkbox" name="checkbox_checked" checked="checked" value="i_am_checked"/>
+    </div>
+
+    <div class="field">
+        checkbox_multiple_checked
+        <input type="checkbox" name="checkbox_multiple_checked" checked="checked" value="checked_one"/>
+        <input type="checkbox" name="checkbox_multiple_checked" checked="checked" value="checked_two"/>
+    </div>
+
+    <div class="field">
+        checkbox_non_checked
+        <input type="checkbox" name="checkbox_non_checked" value="not_checked_one"/>
+        <input type="checkbox" name="checkbox_non_checked" value="not_checked_two"/>
+    </div>
+
+    <input type="submit" value="OK" formmethod="POST">
+</form>
+</body>
+</html>


### PR DESCRIPTION
...cause it didn't return same values and hadn't tests yet.

Only problem I encountered is when multiple values are initially checked in checkbox with multiple values allowed. In this case Goutte returned one value as string instead of multiple values as an array. I'll investigate this one further - maybe it's a bug in Goutte?!? For now I've skipped test for this case.

I'm keen on feedback! :male_detective:  