### PR TITLE
Fix setValue for TextareaFormField and text based InputFormField

### DIFF
--- a/src/DomCrawler/Field/FormFieldTrait.php
+++ b/src/DomCrawler/Field/FormFieldTrait.php
@@ -57,7 +57,7 @@ trait FormFieldTrait
     private function setTextValue($value): void
     {
         // Ensure to clean field before sending keys.
-        // Unable use $this->element->clear(); cause it triggers a change event on it's own which is unexpected behavior.
+        // Unable to use $this->element->clear(); because it triggers a change event on it's own which is unexpected behavior.
         $existingValueLength = \strlen($this->getValue());
         $deleteKeys = \str_repeat(WebDriverKeys::BACKSPACE.WebDriverKeys::DELETE, $existingValueLength);
         $this->element->sendKeys($deleteKeys.$value);

--- a/src/DomCrawler/Field/FormFieldTrait.php
+++ b/src/DomCrawler/Field/FormFieldTrait.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Symfony\Component\Panther\DomCrawler\Field;
 
 use Facebook\WebDriver\WebDriverElement;
+use Facebook\WebDriver\WebDriverKeys;
 use Symfony\Component\Panther\ExceptionThrower;
 
 /**
@@ -48,13 +49,17 @@ trait FormFieldTrait
         return $this->element->getAttribute('value');
     }
 
-    public function setValue($value)
-    {
-        \is_bool($value) ? $this->element->click() : $this->element->sendKeys($value);
-    }
-
     public function isDisabled()
     {
         return $this->element->getAttribute('disabled') ?? false;
+    }
+
+    private function setTextValue($value): void
+    {
+        // Ensure to clean field before sending keys.
+        // Unable use $this->element->clear(); cause it triggers a change event on it's own which is unexpected behavior.
+        $existingValueLength = \strlen($this->getValue());
+        $deleteKeys = \str_repeat(WebDriverKeys::BACKSPACE.WebDriverKeys::DELETE, $existingValueLength);
+        $this->element->sendKeys($deleteKeys.$value);
     }
 }

--- a/src/DomCrawler/Field/InputFormField.php
+++ b/src/DomCrawler/Field/InputFormField.php
@@ -24,7 +24,7 @@ final class InputFormField extends BaseInputFormField
 
     public function setValue($value)
     {
-        if (\in_array($this->element->getAttribute('type'), ['text'])) {
+        if (\in_array($this->element->getAttribute('type'), ['text'], true)) {
             $this->setTextValue($value);
         } elseif (\is_bool($value)) {
             $this->element->click();

--- a/src/DomCrawler/Field/InputFormField.php
+++ b/src/DomCrawler/Field/InputFormField.php
@@ -22,6 +22,17 @@ final class InputFormField extends BaseInputFormField
 {
     use FormFieldTrait;
 
+    public function setValue($value)
+    {
+        if (\in_array($this->element->getAttribute('type'), ['text'])) {
+            $this->setTextValue($value);
+        } elseif (\is_bool($value)) {
+            $this->element->click();
+        } else {
+            $this->element->sendKeys($value);
+        }
+    }
+
     /**
      * Initializes the form field.
      *

--- a/src/DomCrawler/Field/TextareaFormField.php
+++ b/src/DomCrawler/Field/TextareaFormField.php
@@ -22,6 +22,11 @@ final class TextareaFormField extends BaseTextareaFormField
 {
     use FormFieldTrait;
 
+    public function setValue($value)
+    {
+        $this->setTextValue($value);
+    }
+
     /**
      * Initializes the form field.
      *

--- a/tests/DomCrawler/Field/InputFormFieldTest.php
+++ b/tests/DomCrawler/Field/InputFormFieldTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Panther project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Panther\Tests\DomCrawler\Field;
+
+use Symfony\Component\DomCrawler\Field\InputFormField;
+use Symfony\Component\Panther\Tests\TestCase;
+
+/**
+ * @author Robert Freigang <robertfreigang@gmx.de>
+ */
+class InputFormFieldTest extends TestCase
+{
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testGetValueWithSomeValueFromTextInput(callable $clientFactory)
+    {
+        $crawler = $this->request($clientFactory, '/input-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var InputFormField */
+        $field = $form['text_input_with_some_value'];
+        $this->assertInstanceOf(InputFormField::class, $field);
+        $this->assertSame('some_value', $field->getValue());
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testGetValueWithNoValueFromTextInput(callable $clientFactory)
+    {
+        $crawler = $this->request($clientFactory, '/input-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var InputFormField */
+        $field = $form['text_input_with_no_value'];
+        $this->assertInstanceOf(InputFormField::class, $field);
+        $this->assertSame('', $field->getValue());
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testSetValueMultipleTimesInTextInput(callable $clientFactory)
+    {
+        $crawler = $this->request($clientFactory, '/input-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var InputFormField */
+        $field = $form['text_input_with_no_value'];
+        $this->assertInstanceOf(InputFormField::class, $field);
+
+        $field->setValue('first_value');
+        $this->assertSame('first_value', $field->getValue());
+
+        $field->setValue('second_value');
+        $this->assertSame('second_value', $field->getValue());
+    }
+}

--- a/tests/DomCrawler/Field/TextareaFormFieldTest.php
+++ b/tests/DomCrawler/Field/TextareaFormFieldTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Panther project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Panther\Tests\DomCrawler\Field;
+
+use Symfony\Component\DomCrawler\Field\TextareaFormField;
+use Symfony\Component\Panther\Tests\TestCase;
+
+/**
+ * @author Robert Freigang <robertfreigang@gmx.de>
+ */
+class TextareaFormFieldTest extends TestCase
+{
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testGetValueWithSomeValue(callable $clientFactory)
+    {
+        $crawler = $this->request($clientFactory, '/textarea-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var TextareaFormField */
+        $field = $form['textarea_with_some_value'];
+        $this->assertInstanceOf(TextareaFormField::class, $field);
+        $this->assertSame('some_value', $field->getValue());
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testGetValueWithNoValue(callable $clientFactory)
+    {
+        $crawler = $this->request($clientFactory, '/textarea-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var TextareaFormField */
+        $field = $form['textarea_with_no_value'];
+        $this->assertInstanceOf(TextareaFormField::class, $field);
+        $this->assertSame('', $field->getValue());
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testSetValueMultipleTimes(callable $clientFactory)
+    {
+        $crawler = $this->request($clientFactory, '/textarea-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var TextareaFormField */
+        $field = $form['textarea_with_no_value'];
+        $this->assertInstanceOf(TextareaFormField::class, $field);
+
+        $field->setValue('first_value');
+        $this->assertSame('first_value', $field->getValue());
+
+        $field->setValue('second_value');
+        $this->assertSame('second_value', $field->getValue());
+    }
+}

--- a/tests/fixtures/input-form-field.html
+++ b/tests/fixtures/input-form-field.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Form with ChoiceFormField</title>
+    <style>
+        label {
+            border: 1px solid lightgrey;
+            display: block;
+        }
+    </style>
+</head>
+<body>
+<form>
+
+    <label class="field">
+        text_input_with_some_value
+        <input name="text_input_with_some_value" type="text" value="some_value" />
+    </label>
+
+    <label class="field">
+        text_input_with_no_value
+        <input name="text_input_with_no_value" type="text" />
+    </label>
+
+    <input type="submit" value="OK">
+</form>
+</body>
+</html>

--- a/tests/fixtures/textarea-form-field.html
+++ b/tests/fixtures/textarea-form-field.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Form with ChoiceFormField</title>
+    <style>
+        label {
+            border: 1px solid lightgrey;
+            display: block;
+        }
+    </style>
+</head>
+<body>
+<form>
+
+    <label class="field">
+        textarea_with_some_value
+        <textarea name="textarea_with_some_value">some_value</textarea>
+    </label>
+
+    <label class="field">
+        textarea_with_no_value
+        <textarea name="textarea_with_no_value"></textarea>
+    </label>
+
+    <input type="submit" value="OK">
+</form>
+</body>
+</html>


### PR DESCRIPTION
... especially when there is already a value given for the field.

This PR did not take non-text types and html5 types into account.
For a complete list of types see: https://www.w3schools.com/tags/att_input_type.asp#midcontentadcontainer