### PR TITLE
Increase a lot (x4) boot sequence

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,8 @@
     "php": ">=7.1",
     "facebook/webdriver": "^1.5",
     "symfony/browser-kit": "^4.0",
+    "symfony/contracts": "^1.1",
+    "symfony/http-client": "^4.3",
     "symfony/polyfill-php72": "^1.9",
     "symfony/process": "^3.4 || ^4.0"
   },

--- a/tests/fixtures/index.php
+++ b/tests/fixtures/index.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * This file is part of the Panther project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+echo 'OK';


### PR DESCRIPTION
1. Use symfony/http-client to get the status of webdriver process
2. Do not wait an extra 1 s

The major point is the first one. I paste here the commit details:

With a simple PHPUnit setup and a 'regular' web page I got the following
numbers:

Before:

> Time: 13.39 seconds, Memory: 6.00MB

After:

> Time: 3.27 seconds, Memory: 6.00MB

I Profiler the page with [blackfire](https://blackfire.io/profiles/60e52757-9b36-4e95-b084-ef34fd83108e/graph).
And I noticed `file_get_contents()` was **very slow**.

I first updated the binary (see previous commit) but without success.

Then I tried to reproduce manually what happend. The chromedrive boot
really fast, and is directly available on HTTP. So there is something wrong
with `file_get_contents()`. I used tcpdump to debug it, and the chrome
driver do well its job. The issue is in PHP :(.

Since we have a nice HTTP client Symfony, let's use it !

Here is the tcpdump of the dial between php and the driver

``` 16:05:44.854533 IP 127.0.0.1.59044 > 127.0.0.1.9515: Flags [P.], seq
1:66, ack 1, win 342, options [nop,nop,TS val 3026213891 ecr 3026213891],
length 65 E..u..@.@.............%+...sO......V.i.....
.`\..`\.GET /status HTTP/1.1 Host: 127.0.0.1:9515 Connection: close

16:05:44.854645 IP 127.0.0.1.9515 > 127.0.0.1.59044: Flags [P.], seq 1:237,
ack 66, win 342, options [nop,nop,TS val 3026213891 ecr 3026213891], length
236 E.. .x@.@..]........%+..O..........V.......
.`\..`\.HTTP/1.1 200 OK Content-Length:133 Content-Type:application/json;
charset=utf-8 Connection:close

{"sessionId":"","status":0,"value":{"build":{"version":"alpha"},"os":{"arch":"x86_64","name":"Linux","version":"4.15.0-46-generic"}}}
16:05:44.854651 IP 127.0.0.1.59044 > 127.0.0.1.9515: Flags [.], ack 237,
win 350, options [nop,nop,TS val 3026213891 ecr 3026213891], length 0
E..4..@.@.............%+....O......^.(.....
.`\..`\.

[< HANG A LOT HERE >]

16:05:54.864184 IP 127.0.0.1.59044 > 127.0.0.1.9515: Flags [F.], seq 66,
ack 237, win 350, options [nop,nop,TS val 3026223901 ecr 3026213891],
length 0 E..4..@.@.............%+....O......^.(.....
.`...`\.
```

---

**EDIT**

I initially thought it will increase only the very boot sequence, but actually it speeds up **eveything**.

With 3 tests:

Before:
> Time: 42.06 seconds, Memory: 6.00MB
After:
> Time: 8.96 seconds, Memory: 6.00MB