### PR TITLE
Add support for DomCrawler's PHPUnit assertions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
 
 before_install:
   - if [[ $lint = '1' ]]; then wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.15.1/php-cs-fixer.phar; fi
-  - if [[ $lint = '1' ]]; then wget https://github.com/phpstan/phpstan/releases/download/0.10.3/phpstan.phar; fi
+  - if [[ $lint = '1' ]]; then wget https://github.com/phpstan/phpstan/releases/download/0.11.15/phpstan.phar; fi
 
 before_script:
   - phpenv config-rm xdebug.ini

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,18 @@
 parameters:
+	inferPrivatePropertyTypeFromConstructor: true
 	ignoreErrors:
+		# https://github.com/symfony/symfony/pull/33289
+		- '#Parameter \#1 \$value of method Symfony\\Component\\Panther\\DomCrawler\\Field\\FileFormField::setValue\(\) expects string, null given\.#'
+		- '#Call to function is_bool\(\) with string will always evaluate to false\.#'
+		# https://github.com/symfony/symfony/pull/33278
+		- '#KernelBrowser#'
+		# False positive
+		- '#Else branch is unreachable because ternary operator condition is always true\.#'
+		- '#Call to private static method getClient\(\) of class Symfony\\Bundle\\FrameworkBundle\\Test\\WebTestCase\.#'
+		- '#Call to an undefined static method Symfony\\Component\\Panther\\PantherTestCase::baseAssertPageTitleContains\(\)\.#'
+		- '#Call to an undefined static method Symfony\\Component\\Panther\\PantherTestCase::baseAssertPageTitleSame\(\)\.#'
+		# To fix in PHP WebDriver
+		- '#Parameter \#2 \$desired_capabilities of static method Facebook\\WebDriver\\Remote\\RemoteWebDriver::create\(\) expects array\|Facebook\\WebDriver\\Remote\\DesiredCapabilities\|null, Facebook\\WebDriver\\WebDriverCapabilities given\.#'
 		# Require a redesign of the underlying Symfony components
 		- '#Panther\\[a-zA-Z\\]+::__construct\(\) does not call parent constructor from Symfony\\Component\\(BrowserKit|DomCrawler)\\[a-zA-Z]+\.#'
+		- '#Return type \(void\) of method Symfony\\Component\\Panther\\DomCrawler\\Crawler::clear\(\) should be compatible with return type \(Facebook\\WebDriver\\WebDriverElement\) of method Facebook\\WebDriver\\WebDriverElement::clear\(\)#'

--- a/src/DomCrawler/Field/FormFieldTrait.php
+++ b/src/DomCrawler/Field/FormFieldTrait.php
@@ -60,7 +60,7 @@ trait FormFieldTrait
         // Unable to use $this->element->clear(); because it triggers a change event on it's own which is unexpected behavior.
 
         $v = $this->getValue();
-        if (is_array($v)) {
+        if (\is_array($v)) {
             throw new \InvalidArgumentException('The value must not be an array');
         }
 

--- a/src/DomCrawler/Field/FormFieldTrait.php
+++ b/src/DomCrawler/Field/FormFieldTrait.php
@@ -58,7 +58,13 @@ trait FormFieldTrait
     {
         // Ensure to clean field before sending keys.
         // Unable to use $this->element->clear(); because it triggers a change event on it's own which is unexpected behavior.
-        $existingValueLength = \strlen($this->getValue());
+
+        $v = $this->getValue();
+        if (is_array($v)) {
+            throw new \InvalidArgumentException('The value must not be an array');
+        }
+
+        $existingValueLength = \strlen($v);
         $deleteKeys = \str_repeat(WebDriverKeys::BACKSPACE.WebDriverKeys::DELETE, $existingValueLength);
         $this->element->sendKeys($deleteKeys.$value);
     }

--- a/src/PantherTestCase.php
+++ b/src/PantherTestCase.php
@@ -13,13 +13,58 @@ declare(strict_types=1);
 
 namespace Symfony\Component\Panther;
 
+use Goutte\Client as GoutteClient;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestAssertionsTrait;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Panther\Client as PantherClient;
 
 if (\class_exists(WebTestCase::class)) {
     abstract class PantherTestCase extends WebTestCase
     {
-        use PantherTestCaseTrait;
+        use PantherTestCaseTrait {
+            createPantherClient as private baseCreatePantherClient;
+            createGoutteClient as private baseCreateGoutteClient;
+        }
+        use WebTestAssertionsTrait {
+            assertPageTitleSame as private baseAssertPageTitleSame;
+            assertPageTitleContains as private baseAssertPageTitleContains;
+        }
+
+        protected static function createPantherClient(array $options = [], array $kernelOptions = []): PantherClient
+        {
+            return self::getClient(self::baseCreatePantherClient($options, $kernelOptions));
+        }
+
+        public static function assertPageTitleSame(string $expectedTitle, string $message = ''): void
+        {
+            $client = self::getClient();
+            if ($client instanceof PantherClient) {
+                self::assertSame($expectedTitle, $client->getTitle());
+
+                return;
+            }
+
+            self::baseAssertPageTitleSame($expectedTitle, $message);
+        }
+
+        public static function assertPageTitleContains(string $expectedTitle, string $message = ''): void
+        {
+            $client = self::getClient();
+            if ($client instanceof PantherClient) {
+                self::assertStringContainsString($expectedTitle, $client->getTitle());
+
+                return;
+            }
+
+            self::baseAssertPageTitleContains($expectedTitle, $message);
+        }
+
+        // Need https://github.com/FriendsOfPHP/Goutte/pull/382 first
+        /*protected static function createGoutteClient(array $options = [], array $kernelOptions = []): GoutteClient
+        {
+            return self::getClient(self::baseCreateGoutteClient($options, $kernelOptions));
+        }*/
     }
 } else {
     abstract class PantherTestCase extends TestCase

--- a/src/PantherTestCase.php
+++ b/src/PantherTestCase.php
@@ -13,58 +13,59 @@ declare(strict_types=1);
 
 namespace Symfony\Component\Panther;
 
-use Goutte\Client as GoutteClient;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestAssertionsTrait;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\Panther\Client as PantherClient;
 
 if (\class_exists(WebTestCase::class)) {
-    abstract class PantherTestCase extends WebTestCase
-    {
-        use PantherTestCaseTrait {
-            createPantherClient as private baseCreatePantherClient;
-            createGoutteClient as private baseCreateGoutteClient;
-        }
-        use WebTestAssertionsTrait {
-            assertPageTitleSame as private baseAssertPageTitleSame;
-            assertPageTitleContains as private baseAssertPageTitleContains;
-        }
+    // Compatibility with buggy 4.3 versions, see https://github.com/symfony/symfony/pull/33278
+    $canUseAssertions = false;
+    try {
+        $canUseAssertions = AbstractBrowser::class === (new \ReflectionMethod(WebTestCase::class, 'getClient'))->getReturnType()->getName();
+    } catch (\ReflectionException $e) {
+        // Old version of WebTestCase
+    }
 
-        protected static function createPantherClient(array $options = [], array $kernelOptions = []): PantherClient
+    if ($canUseAssertions) {
+        abstract class PantherTestCase extends WebTestCase
         {
-            return self::getClient(self::baseCreatePantherClient($options, $kernelOptions));
-        }
-
-        public static function assertPageTitleSame(string $expectedTitle, string $message = ''): void
-        {
-            $client = self::getClient();
-            if ($client instanceof PantherClient) {
-                self::assertSame($expectedTitle, $client->getTitle());
-
-                return;
+            use PantherTestCaseTrait;
+            use WebTestAssertionsTrait {
+                assertPageTitleSame as private baseAssertPageTitleSame;
+                assertPageTitleContains as private baseAssertPageTitleContains;
             }
 
-            self::baseAssertPageTitleSame($expectedTitle, $message);
-        }
+            public static function assertPageTitleSame(string $expectedTitle, string $message = ''): void
+            {
+                $client = self::getClient();
+                if ($client instanceof PantherClient) {
+                    self::assertSame($expectedTitle, $client->getTitle());
 
-        public static function assertPageTitleContains(string $expectedTitle, string $message = ''): void
-        {
-            $client = self::getClient();
-            if ($client instanceof PantherClient) {
-                self::assertStringContainsString($expectedTitle, $client->getTitle());
+                    return;
+                }
 
-                return;
+                self::baseAssertPageTitleSame($expectedTitle, $message);
             }
 
-            self::baseAssertPageTitleContains($expectedTitle, $message);
-        }
+            public static function assertPageTitleContains(string $expectedTitle, string $message = ''): void
+            {
+                $client = self::getClient();
+                if ($client instanceof PantherClient) {
+                    self::assertStringContainsString($expectedTitle, $client->getTitle());
 
-        // Need https://github.com/FriendsOfPHP/Goutte/pull/382 first
-        /*protected static function createGoutteClient(array $options = [], array $kernelOptions = []): GoutteClient
+                    return;
+                }
+
+                self::baseAssertPageTitleContains($expectedTitle, $message);
+            }
+        }
+    } else {
+        abstract class PantherTestCase extends WebTestCase
         {
-            return self::getClient(self::baseCreateGoutteClient($options, $kernelOptions));
-        }*/
+            use PantherTestCaseTrait;
+        }
     }
 } else {
     abstract class PantherTestCase extends TestCase

--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -143,7 +143,7 @@ trait PantherTestCaseTrait
             static::bootKernel($kernelOptions);
         }
 
-        if (is_callable([self::class, 'getClient'])) {
+        if (\is_callable([self::class, 'getClient'])) {
             return self::getClient(self::$pantherClient);
         }
 

--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -143,7 +143,7 @@ trait PantherTestCaseTrait
             static::bootKernel($kernelOptions);
         }
 
-        if (method_exists(self::class, 'getClient')) {
+        if (is_callable([self::class, 'getClient'])) {
             return self::getClient(self::$pantherClient);
         }
 

--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -143,6 +143,10 @@ trait PantherTestCaseTrait
             static::bootKernel($kernelOptions);
         }
 
+        if (method_exists(self::class, 'getClient')) {
+            return self::getClient(self::$pantherClient);
+        }
+
         return self::$pantherClient;
     }
 
@@ -168,6 +172,7 @@ trait PantherTestCaseTrait
             static::bootKernel($kernelOptions);
         }
 
+        // It's not possible to use assertions with Goutte yet, https://github.com/FriendsOfPHP/Goutte/pull/382 needed
         return self::$goutteClient;
     }
 

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -13,10 +13,21 @@ declare(strict_types=1);
 
 namespace Symfony\Component\Panther\Tests;
 
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\BrowserKit\AbstractBrowser;
+
 class AssertionsTest extends TestCase
 {
     public function testDomCrawlerAssertions(): void
     {
+        try {
+            if (AbstractBrowser::class !== (new \ReflectionMethod(WebTestCase::class, 'getClient'))->getReturnType()->getName()) {
+                $this->markTestSkipped('Old version of WebTestCase');
+            }
+        } catch (\ReflectionException $e) {
+            $this->markTestSkipped('Old version of WebTestCase');
+        }
+
         self::createPantherClient()->request('GET', '/basic.html');
         $this->assertSelectorExists('.p-1');
         $this->assertSelectorNotExists('#notexist');

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Panther project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Panther\Tests;
+
+class AssertionsTest extends TestCase
+{
+    public function testDomCrawlerAssertions(): void
+    {
+        self::createPantherClient()->request('GET', '/basic.html');
+        $this->assertSelectorExists('.p-1');
+        $this->assertSelectorNotExists('#notexist');
+        $this->assertSelectorTextContains('body', 'P1');
+        $this->assertSelectorTextSame('.p-1', 'P1');
+        $this->assertSelectorTextNotContains('.p-1', 'not contained');
+        $this->assertPageTitleSame('A basic page');
+        $this->assertPageTitleContains('A basic');
+        $this->assertInputValueNotSame('in', '');
+        $this->assertInputValueSame('in', 'test');
+    }
+}

--- a/tests/DomCrawler/CrawlerTest.php
+++ b/tests/DomCrawler/CrawlerTest.php
@@ -194,7 +194,7 @@ class CrawlerTest extends TestCase
             $names[$i] = $c->nodeName();
         });
 
-        $this->assertSame(['h1', 'main', 'p', 'p'], $names);
+        $this->assertSame(['h1', 'main', 'p', 'p', 'input'], $names);
     }
 
     /**

--- a/tests/DummyKernel.php
+++ b/tests/DummyKernel.php
@@ -15,7 +15,6 @@ namespace Symfony\Component\Panther\Tests;
 
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\KernelInterface;
 

--- a/tests/DummyKernel.php
+++ b/tests/DummyKernel.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Symfony\Component\Panther\Tests;
 
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -80,14 +82,37 @@ class DummyKernel implements KernelInterface
 
     public function getContainer()
     {
-        return new class() implements \Psr\Container\ContainerInterface {
-            public function get($id)
+        return new class() implements ContainerInterface {
+            public function get($id, $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE)
             {
             }
 
             public function has($id)
             {
                 return false;
+            }
+
+            public function set($id, $service)
+            {
+            }
+
+            public function initialized($id)
+            {
+                return true;
+            }
+
+            public function getParameter($name)
+            {
+                return null;
+            }
+
+            public function hasParameter($name)
+            {
+                return false;
+            }
+
+            public function setParameter($name, $value)
+            {
             }
         };
     }
@@ -105,6 +130,10 @@ class DummyKernel implements KernelInterface
     }
 
     public function getCharset()
+    {
+    }
+
+    public function getProjectDir()
     {
     }
 }

--- a/tests/fixtures/basic.html
+++ b/tests/fixtures/basic.html
@@ -14,5 +14,6 @@
     </main>
     <p class="p-1">P1</p>
     <p class="p-2">P2</p>
+    <input name="in" value="test">
 </body>
 </html>


### PR DESCRIPTION
Allow to use [all DomCrawler assertions introduced in Symfony 4.3](https://symfony.com/doc/current/testing/functional_tests_assertions.html#crawler) with Panther.

Example:

```php
<?php

class AssertionsTest extends PantherTestCase
{
    public function testDomCrawlerAssertions(): void
    {
        self::createPantherClient()->request('GET', '/basic.html');
        $this->assertSelectorExists('.p-1');
        $this->assertSelectorNotExists('#notexist');
        $this->assertSelectorTextContains('body', 'P1');
        $this->assertSelectorTextSame('.p-1', 'P1');
        $this->assertSelectorTextNotContains('.p-1', 'not contained');
        $this->assertPageTitleSame('A basic page');
        $this->assertPageTitleContains('A basic');
        $this->assertInputValueNotSame('in', '');
        $this->assertInputValueSame('in', 'test');
    }
}
```

Requires symfony/symfony#32207.