### PR TITLE
Start the webserver  even if the status isn't 200, relax timeouts

### DIFF
--- a/src/ProcessManager/WebServerManager.php
+++ b/src/ProcessManager/WebServerManager.php
@@ -77,7 +77,7 @@ final class WebServerManager
             $url .= $this->readinessPath;
         }
 
-        $this->waitUntilReady($this->process, $url, 'web server');
+        $this->waitUntilReady($this->process, $url, 'web server', true);
     }
 
     /**

--- a/src/ProcessManager/WebServerReadinessProbeTrait.php
+++ b/src/ProcessManager/WebServerReadinessProbeTrait.php
@@ -38,7 +38,7 @@ trait WebServerReadinessProbeTrait
         }
     }
 
-    public function waitUntilReady(Process $process, string $url, string $service, int $timeout = 5): void
+    public function waitUntilReady(Process $process, string $url, string $service, bool $allowNotOkStatusCode = false, int $timeout = 30): void
     {
         $client = HttpClient::create(['timeout' => $timeout]);
 
@@ -56,12 +56,11 @@ trait WebServerReadinessProbeTrait
                 continue;
             }
 
-            $ready = false;
-
             $response = $client->request('GET', $url);
             $e = $statusCode = null;
             try {
-                if (200 === $statusCode = $response->getStatusCode()) {
+                $statusCode = $response->getStatusCode();
+                if ($allowNotOkStatusCode || 200 === $statusCode) {
                     return;
                 }
             } catch (ExceptionInterface $e) {

--- a/tests/fixtures/index.php
+++ b/tests/fixtures/index.php
@@ -11,4 +11,5 @@
 
 declare(strict_types=1);
 
-echo 'OK';
+http_response_code(500); // The web server must start even in case of error
+echo 'ready';


### PR DESCRIPTION
Fixes some "regressions" introduced by #181:

* the PHP built-in web server must start even if the homepage of the app we are testing doesn't return 200 OK. For instance, when installing API Platform with `composer req api`, the homepage is a 404 (because Swagger UI is on `/api`), and it prevents Panther from starting. We also want to run the test suite entirely even if the homepage is broken and throws an exception.
* relax the timeout from 5s to 30s because currently it fails on slow machines (including CI boxes with high load) for no reasons

Closes #208 and #200.