### PR TITLE
Mercure and WebSocket testing: allow to create several browser instances

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -71,6 +71,11 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
         $this->baseUri = $baseUri;
     }
 
+    public function getBrowserManager(): BrowserManagerInterface
+    {
+        return $this->browserManager;
+    }
+
     public function __destruct()
     {
         $this->quit();
@@ -242,7 +247,7 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
             $this->webDriver->manage()->deleteAllCookies();
         }
 
-        $this->quit();
+        $this->quit(false);
         $this->start();
     }
 
@@ -334,13 +339,16 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
         return $this->webDriver->getWindowHandles();
     }
 
-    public function quit()
+    public function quit(bool $quitBrowserManager = true)
     {
         if (null !== $this->webDriver) {
             $this->webDriver->quit();
             $this->webDriver = null;
         }
-        $this->browserManager->quit();
+
+        if ($quitBrowserManager) {
+            $this->browserManager->quit();
+        }
     }
 
     public function takeScreenshot($saveAs = null)

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -265,7 +265,7 @@ JS
     public function testServerPort(callable $clientFactory): void
     {
         $expectedPort = $_SERVER['PANTHER_WEB_SERVER_PORT'] ?? '9080';
-        $client = $clientFactory();
+        $clientFactory();
         $this->assertEquals($expectedPort, \mb_substr(self::$baseUri, -4));
     }
 }

--- a/tests/MultiClientsTest.php
+++ b/tests/MultiClientsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Panther project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Panther\Tests;
+
+class MultiClientsTest extends TestCase
+{
+    public function testMultiClient(): void
+    {
+        $client = self::createPantherClient();
+        $client->request('GET', '/cookie.php');
+
+        $crawler = $client->request('GET', '/cookie.php');
+        $this->assertSame('1', $crawler->filter('#barcelona')->text());
+
+        $client2 = self::createAdditionalPantherClient();
+        $crawler2 = $client2->request('GET', '/cookie.php');
+        $this->assertSame('0', $crawler2->filter('#barcelona')->text());
+
+        // Check that the cookie in the other client hasn't changed
+        $this->assertSame('1', $crawler->filter('#barcelona')->text());
+    }
+}


### PR DESCRIPTION
Easily test applications using [Mercure](https://mercure.rocks), WebSocket and similar technologies with Panther!

This PR introduces a new method to create additional extra, isolated, browsers; that can interact with the primary one. For instance, it can be useful to test a chat application:

```php
use Symfony\Component\Panther\PantherTestCase;

class ChatTest extends PantherTestCase
{
    public function testMultiClient(): void
    {

        $client1 = self::createPantherClient()
        $client1->request('GET', '/chat'); 
        // Connect a 2nd user, using an isolated browser
        $crawler2 = self::createAdditionalPantherClient()->request('GET', '/chat');

        // Say hi
        $crawler2->submitForm('Post message', ['message' => 'Hi folks']);

        // Wait for the message to be propagated
        $client1->waitFor('.message');
        $this->assertSelectorTextContains('.message', 'Hi folks'); // Assertions are always executed in the PRIMARY browser; but you can use the crawler of the other browsers directly if needed
    }
}
```