### PR TITLE
Prevent call of self::getClient when not in static context

### DIFF
--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -159,7 +159,10 @@ trait PantherTestCaseTrait
         }
 
         if (\is_callable([self::class, 'getClient'])) {
-            return self::getClient(self::$pantherClient);
+            $rm = new \ReflectionMethod(self::class, 'getClient');
+            if ($rm->isStatic()) {
+                return self::getClient(self::$pantherClient);
+            }
         }
 
         return self::$pantherClient;

--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -158,11 +158,8 @@ trait PantherTestCaseTrait
             static::bootKernel($kernelOptions);
         }
 
-        if (\is_callable([self::class, 'getClient'])) {
-            $rm = new \ReflectionMethod(self::class, 'getClient');
-            if ($rm->isStatic()) {
-                return self::getClient(self::$pantherClient);
-            }
+        if (\is_callable([self::class, 'getClient']) && (new \ReflectionMethod(self::class, 'getClient'))->isStatic()) {
+            return self::getClient(self::$pantherClient);
         }
 
         return self::$pantherClient;


### PR DESCRIPTION
...cause it will break when PantherTestCaseTrait is used in a class
which implements and uses getClient with object context.

This maybe-issue was introduced with:
https://github.com/symfony/panther/commit/b9225b01285b67b857fabb7c9211c473a7687e49

In my specific case I have a method in object context wich will break my test application:
https://github.com/robertfausk/mink-panther-driver/blob/master/src/PantherDriver.php#L62