### PR TITLE
Allow to override APP_ENV passed to the web server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.5.1
+-----
+
+* Allow to override the `APP_ENV` environment variable passed to the web server by setting `PANTHER_APP_ENV`
+
 0.5.0
 -----
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ The following environment variables can be set to change some Panther's behaviou
 * `PANTHER_WEB_SERVER_ROUTER`:  to use a web server router script which is run at the start of each HTTP request
 * `PANTHER_EXTERNAL_BASE_URI`: to use an external web server (the PHP built-in web server will not be started)
 * `PANTHER_CHROME_BINARY`: to use another `google-chrome` binary
+* `PANTHER_APP_ENV`: to override the `APP_ENV` variable passed to the web server running the PHP app
 
 ### Accessing To Hidden Text
 

--- a/src/ProcessManager/WebServerManager.php
+++ b/src/ProcessManager/WebServerManager.php
@@ -46,6 +46,11 @@ final class WebServerManager
             throw new \RuntimeException('Unable to find the PHP binary.');
         }
 
+        $env = null;
+        if (isset($_SERVER['PANTHER_APP_ENV'])) {
+            $env = ['APP_ENV' => $_SERVER['PANTHER_APP_ENV']];
+        }
+
         $this->process = new Process(
             array_filter(array_merge(
                 [$binary],
@@ -60,7 +65,7 @@ final class WebServerManager
                 ]
             )),
             $documentRoot,
-            null,
+            $env,
             null,
             null
         );


### PR DESCRIPTION
It will allow to use a specific env for the PHP app started by Panther.
Closes #195 #159.