### PR TITLE
Fix using assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.5.2
+-----
+
+* Fix a bug occurring when using a non-fresh client
+
 0.5.1
 -----
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,7 +10,9 @@ parameters:
 		- '#KernelBrowser#'
 		# False positive
 		- '#Else branch is unreachable because ternary operator condition is always true\.#'
-		- '#Call to private static method getClient\(\) of class Symfony\\Bundle\\FrameworkBundle\\Test\\WebTestCase\.#'
+		- '#getClient#'
+		- '#Result of && is always false\.#'
+		- '#Ternary operator condition is always false\.#'
 		- '#Call to an undefined static method Symfony\\Component\\Panther\\PantherTestCase::baseAssertPageTitleContains\(\)\.#'
 		- '#Call to an undefined static method Symfony\\Component\\Panther\\PantherTestCase::baseAssertPageTitleSame\(\)\.#'
 		- '#Call to function method_exists\(\) with #'

--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -146,8 +146,9 @@ trait PantherTestCaseTrait
      */
     protected static function createPantherClient(array $options = [], array $kernelOptions = []): PantherClient
     {
+        $callGetClient = \is_callable([self::class, 'getClient']) && (new \ReflectionMethod(self::class, 'getClient'))->isStatic();
         if (null !== self::$pantherClient) {
-            return self::$pantherClient;
+            return $callGetClient ? self::getClient(self::$pantherClient) : self::$pantherClient;
         }
 
         self::startWebServer($options);
@@ -158,11 +159,7 @@ trait PantherTestCaseTrait
             static::bootKernel($kernelOptions);
         }
 
-        if (\is_callable([self::class, 'getClient']) && (new \ReflectionMethod(self::class, 'getClient'))->isStatic()) {
-            return self::getClient(self::$pantherClient);
-        }
-
-        return self::$pantherClient;
+        return $callGetClient ? self::getClient(self::$pantherClient) : self::$pantherClient;
     }
 
     /**

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\BrowserKit\AbstractBrowser;
 
 class AssertionsTest extends TestCase
 {
-    public function testDomCrawlerAssertions(): void
+    protected function setUp(): void
     {
         try {
             if (AbstractBrowser::class !== (new \ReflectionMethod(WebTestCase::class, 'getClient'))->getReturnType()->getName()) {
@@ -27,7 +27,10 @@ class AssertionsTest extends TestCase
         } catch (\ReflectionException $e) {
             $this->markTestSkipped('Old version of WebTestCase');
         }
+    }
 
+    public function testDomCrawlerAssertions(): void
+    {
         self::createPantherClient()->request('GET', '/basic.html');
         $this->assertSelectorExists('.p-1');
         $this->assertSelectorNotExists('#notexist');
@@ -38,5 +41,11 @@ class AssertionsTest extends TestCase
         $this->assertPageTitleContains('A basic');
         $this->assertInputValueNotSame('in', '');
         $this->assertInputValueSame('in', 'test');
+    }
+
+    public function testAssertionsWorkEvenWhenTheClientIsNotFresh(): void
+    {
+        self::createPantherClient()->request('GET', '/basic.html');
+        $this->assertSelectorExists('.p-1');
     }
 }


### PR DESCRIPTION
The instance of the client stored in the `static` local variable in `getClient` is reset between every tests. Assertions then work properly only in the first test of the class. This PR fixes that.