### PR TITLE
Crawlers attr() function can return null

### DIFF
--- a/src/DomCrawler/Crawler.php
+++ b/src/DomCrawler/Crawler.php
@@ -166,7 +166,7 @@ final class Crawler extends BaseCrawler implements WebDriverElement
         return $this->createSubCrawlerFromXpath($xpath);
     }
 
-    public function attr($attribute): string
+    public function attr($attribute): ?string
     {
         $element = $this->getElementOrThrow();
         if ('_text' === $attribute) {


### PR DESCRIPTION
Problem: The declared return type of the `attr()` method in `Crawler` is `string`. 

If an attribute could not be found the `getAttribute()` method in `WebDriverElement` returns `null`. That's why `attr()` is throwing an `TypeError` exception even though it should return null. 

Added that the return type can be null.

