### PR TITLE
Allow waitFor to wait for any present element

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -277,7 +277,7 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
             : WebDriverBy::xpath($locator);
 
         $this->wait($timeoutInSecond, $intervalInMillisecond)->until(
-            WebDriverExpectedCondition::visibilityOfElementLocated($by)
+            WebDriverExpectedCondition::presenceOfElementLocated($by)
         );
 
         return $this->crawler = $this->createCrawler();

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -73,6 +73,15 @@ class ClientTest extends TestCase
         ];
     }
 
+    public function testWaitForInvisibleElement(): void
+    {
+        $client = self::createPantherClient();
+        $crawler = $client->request('GET', '/waitfor-invisible.html');
+        $c = $client->waitFor('#hello');
+        $this->assertInstanceOf(Crawler::class, $c);
+        $this->assertSame('Hello', $crawler->filter('#hello')->getAttribute('value'));
+    }
+
     public function testExecuteScript()
     {
         $client = self::createPantherClient();

--- a/tests/fixtures/waitfor-invisible.html
+++ b/tests/fixtures/waitfor-invisible.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>WaitFor - Invisible Element</title>
+</head>
+<body>
+<div id="root"></div>
+
+<template id="t-hello">
+    <input type="hidden" id="hello" value="Hello">
+</template>
+
+<script>
+    window.setTimeout(function () {
+        document.getElementById('root').appendChild(
+            document.importNode(document.getElementById('t-hello').content, true)
+        );
+    }, 1000);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Current `waitfFor()` method only targets visible elements, which makes impossible to check for hidden inputs presence for example.
This patch allows it to target any element.