### PR TITLE
Support xpath expressions in Client::waitFor()

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -259,14 +259,14 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
     }
 
     /**
-     * @param string $locator The path to an element to be waited for. Can be a CSS selector or Xpath expression.
-     * @param int $timeoutInSecond
-     * @param int $intervalInMillisecond
-     *
-     * @return Crawler
+     * @param string $locator               The path to an element to be waited for. Can be a CSS selector or Xpath expression.
+     * @param int    $timeoutInSecond
+     * @param int    $intervalInMillisecond
      *
      * @throws NoSuchElementException
      * @throws TimeOutException
+     *
+     * @return Crawler
      */
     public function waitFor(string $locator, int $timeoutInSecond = 30, int $intervalInMillisecond = 250)
     {

--- a/src/Client.php
+++ b/src/Client.php
@@ -266,7 +266,11 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
      */
     public function waitFor(string $locator, int $timeoutInSecond = 30, int $intervalInMillisecond = 250)
     {
-        $by = '/' === $locator[0] ? WebDriverBy::xpath($locator) : WebDriverBy::cssSelector($locator);
+        $locator = trim($locator);
+
+        $by = '' === $locator || '/' !== $locator[0]
+            ? WebDriverBy::cssSelector($locator)
+            : WebDriverBy::xpath($locator);
 
         $this->wait($timeoutInSecond, $intervalInMillisecond)->until(
             WebDriverExpectedCondition::visibilityOfElementLocated($by)

--- a/src/Client.php
+++ b/src/Client.php
@@ -264,10 +264,12 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
      *
      * @return Crawler
      */
-    public function waitFor(string $cssSelector, int $timeoutInSecond = 30, int $intervalInMillisecond = 250)
+    public function waitFor(string $locator, int $timeoutInSecond = 30, int $intervalInMillisecond = 250)
     {
+        $by = '/' === $locator[0] ? WebDriverBy::xpath($locator) : WebDriverBy::cssSelector($locator);
+
         $this->wait($timeoutInSecond, $intervalInMillisecond)->until(
-            WebDriverExpectedCondition::visibilityOfElementLocated(WebDriverBy::cssSelector($cssSelector))
+            WebDriverExpectedCondition::visibilityOfElementLocated($by)
         );
 
         return $this->crawler = $this->createCrawler();

--- a/src/Client.php
+++ b/src/Client.php
@@ -259,10 +259,14 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
     }
 
     /**
-     * @throws NoSuchElementException
-     * @throws TimeOutException
+     * @param string $locator The path to an element to be waited for. Can be a CSS selector or Xpath expression.
+     * @param int $timeoutInSecond
+     * @param int $intervalInMillisecond
      *
      * @return Crawler
+     *
+     * @throws NoSuchElementException
+     * @throws TimeOutException
      */
     public function waitFor(string $locator, int $timeoutInSecond = 30, int $intervalInMillisecond = 250)
     {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -39,13 +39,28 @@ class ClientTest extends TestCase
         $this->assertInstanceOf(KernelInterface::class, self::$kernel);
     }
 
-    public function testWaitFor()
+    /**
+     * @dataProvider waitForDataProvider
+     */
+    public function testWaitFor(string $locator)
     {
         $client = self::createPantherClient();
         $crawler = $client->request('GET', '/waitfor.html');
-        $c = $client->waitFor('#hello');
+        $c = $client->waitFor($locator);
         $this->assertInstanceOf(Crawler::class, $c);
         $this->assertSame('Hello', $crawler->filter('#hello')->text());
+    }
+
+    public function waitForDataProvider(): array
+    {
+        return [
+            'css selector' => [
+                'locator' => '#hello',
+            ],
+            'xpath expression' => [
+                'locator' => '//*[@id="hello"]',
+            ],
+        ];
     }
 
     public function testExecuteScript()

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -45,10 +45,8 @@ class ClientTest extends TestCase
         $this->expectException(InvalidSelectorException::class);
 
         $client = self::createPantherClient();
-        $crawler = $client->request('GET', '/waitfor.html');
-        $c = $client->waitFor('');
-        $this->assertInstanceOf(Crawler::class, $c);
-        $this->assertSame('Hello', $crawler->filter('#hello')->text());
+        $client->request('GET', '/waitfor.html');
+        $client->waitFor('');
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Symfony\Component\Panther\Tests;
 
+use Facebook\WebDriver\Exception\InvalidSelectorException;
 use Facebook\WebDriver\JavaScriptExecutor;
 use Facebook\WebDriver\WebDriver;
 use Facebook\WebDriver\WebDriverExpectedCondition;
@@ -37,6 +38,17 @@ class ClientTest extends TestCase
         $this->assertInstanceOf(WebDriver::class, $client);
         $this->assertInstanceOf(JavaScriptExecutor::class, $client);
         $this->assertInstanceOf(KernelInterface::class, self::$kernel);
+    }
+
+    public function testWaitForEmptyLocator()
+    {
+        $this->expectException(InvalidSelectorException::class);
+
+        $client = self::createPantherClient();
+        $crawler = $client->request('GET', '/waitfor.html');
+        $c = $client->waitFor('');
+        $this->assertInstanceOf(Crawler::class, $c);
+        $this->assertSame('Hello', $crawler->filter('#hello')->text());
     }
 
     /**


### PR DESCRIPTION
Fixes #238 

At present, `Client::waitFor()` accepts as the first argument a CSS selector. This inherently rules out identifying the element to be waited for using an xpath expression.

This change allows the first argument of `Client::waitFor()` to be either a CSS selector or xpath expression. 

An xpath expression always starts with a single forward slash whereas a CSS selector never does. This allows us to differentiate between CSS selectors and xpath expressions and to behave accordingly.