### PR TITLE
phpstan: ignore unmatched ignored errors

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,6 +2,7 @@ parameters:
 	autoload_files:
 		- vendor/bin/.phpunit/phpunit-7.4/vendor/autoload.php
 	inferPrivatePropertyTypeFromConstructor: true
+	reportUnmatchedIgnoredErrors: false
 	ignoreErrors:
 		# https://github.com/symfony/symfony/pull/33289
 		- '#Parameter \#1 \$value of method Symfony\\Component\\Panther\\DomCrawler\\Field\\FileFormField::setValue\(\) expects string, null given\.#'


### PR DESCRIPTION
Fixes #246 

phpstan is configured to ignore some errors. Of these, some are only present under PHP 7.1 or 7.2 and are not present under PHP 7.3.

By default phpstan will return a non-zero return code if an ignored error pattern is not matched. This is currently the case when invoking phpstan on travis under PHP 7.3 and is causing all current PR builds to fail.

This change adds `reportUnmatchedIgnoredErrors: false` to the phpstan configuration such that phpstan will be silent about unmatched ignored errors.