### PR TITLE
Check if webserver process terminated

### DIFF
--- a/src/ProcessManager/WebServerReadinessProbeTrait.php
+++ b/src/ProcessManager/WebServerReadinessProbeTrait.php
@@ -47,7 +47,7 @@ trait WebServerReadinessProbeTrait
         while (true) {
             $status = $process->getStatus();
             if (Process::STATUS_STARTED !== $status) {
-                if (microtime(true) - $start >= $timeout) {
+                if (Process::STATUS_TERMINATED === $status || microtime(true) - $start >= $timeout) {
                     throw new \RuntimeException("Could not start $service (or it crashed) after $timeout seconds.");
                 }
 


### PR DESCRIPTION
When starting the webserver and it terminates, currently you have to wait for the entire timeout before getting any feedback. So this change proposes to throw an exception immediately if the process terminated and get feedback sooner