### PR TITLE
Throw explanative `LogicException` when driver is not started yet

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -420,7 +420,7 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
     public function executeScript($script, array $arguments = [])
     {
         if (!$this->webDriver instanceof JavaScriptExecutor) {
-            throw new \RuntimeException(sprintf('"%s" does not implement "%s".', \get_class($this->webDriver), JavaScriptExecutor::class));
+            $this->throwException(JavaScriptExecutor::class);
         }
 
         return $this->webDriver->executeScript($script, $arguments);
@@ -429,7 +429,7 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
     public function executeAsyncScript($script, array $arguments = [])
     {
         if (!$this->webDriver instanceof JavaScriptExecutor) {
-            throw new \RuntimeException(sprintf('"%s" does not implement "%s".', \get_class($this->webDriver), JavaScriptExecutor::class));
+            $this->throwException(JavaScriptExecutor::class);
         }
 
         return $this->webDriver->executeAsyncScript($script, $arguments);
@@ -438,7 +438,7 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
     public function getKeyboard()
     {
         if (!$this->webDriver instanceof WebDriverHasInputDevices) {
-            throw new \RuntimeException(sprintf('"%s" does not implement "%s".', \get_class($this->webDriver), WebDriverHasInputDevices::class));
+            $this->throwException(WebDriverHasInputDevices::class);
         }
 
         return $this->webDriver->getKeyboard();
@@ -447,9 +447,17 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
     public function getMouse(): WebDriverMouse
     {
         if (!$this->webDriver instanceof WebDriverHasInputDevices) {
-            throw new \RuntimeException(sprintf('"%s" does not implement "%s".', \get_class($this->webDriver), WebDriverHasInputDevices::class));
+            $this->throwException(WebDriverHasInputDevices::class);
         }
 
         return new WebDriverMouse($this->webDriver->getMouse(), $this);
+    }
+
+    private function throwException(string $implementableClass): void
+    {
+        if (null === $this->webDriver) {
+            throw new \LogicException(sprintf('WebDriver not started yet. Call method `start()` first before calling any `%s` method.', $implementableClass));
+        }
+        throw new \RuntimeException(sprintf('"%s" does not implement "%s".', \get_class($this->webDriver), $implementableClass));
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -17,6 +17,7 @@ use Facebook\WebDriver\Exception\InvalidSelectorException;
 use Facebook\WebDriver\JavaScriptExecutor;
 use Facebook\WebDriver\WebDriver;
 use Facebook\WebDriver\WebDriverExpectedCondition;
+use LogicException;
 use Symfony\Component\BrowserKit\Client as BrowserKitClient;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\BrowserKit\CookieJar as BrowserKitCookieJar;
@@ -88,6 +89,13 @@ class ClientTest extends TestCase
         $client->request('GET', '/basic.html');
         $innerText = $client->executeScript('return document.querySelector(arguments[0]).innerText;', ['.p-1']);
         $this->assertSame('P1', $innerText);
+    }
+
+    public function testExecuteScriptLogicExceptionWhenDriverIsNotStartedYet()
+    {
+        $this->expectException(LogicException::class);
+        $client = Client::createChromeClient();
+        $client->executeScript('return document.querySelector(arguments[0]).innerText;', ['.p-1']);
     }
 
     public function testExecuteAsyncScript()

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -17,8 +17,7 @@ use Facebook\WebDriver\Exception\InvalidSelectorException;
 use Facebook\WebDriver\JavaScriptExecutor;
 use Facebook\WebDriver\WebDriver;
 use Facebook\WebDriver\WebDriverExpectedCondition;
-use LogicException;
-use Symfony\Component\BrowserKit\Client as BrowserKitClient;
+use Symfony\Component\BrowserKit\AbstractBrowser as BrowserKitClient;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\BrowserKit\CookieJar as BrowserKitCookieJar;
 use Symfony\Component\DomCrawler\Crawler as DomCrawlerCrawler;
@@ -93,7 +92,7 @@ class ClientTest extends TestCase
 
     public function testExecuteScriptLogicExceptionWhenDriverIsNotStartedYet()
     {
-        $this->expectException(LogicException::class);
+        $this->expectException(\LogicException::class);
         $client = Client::createChromeClient();
         $client->executeScript('return document.querySelector(arguments[0]).innerText;', ['.p-1']);
     }


### PR DESCRIPTION
When `executeScript` gets called before the client made a request, an exception should get thrown. The problem; the actual `RuntimeException` can not get created because driver is `null`.

This PR clarifies that these methods can not get called before the driver is started.

Failing test on linting / phpstan does not seem related (?). Is it because of the 0.12 phpstan release of several days ago?