### PR TITLE
Rename php-webdriver package

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Since Panther implements the API of popular libraries, it already has extensive 
 
 * For the `Client` class, read [the BrowserKit documentation](https://symfony.com/doc/current/components/browser_kit.html)
 * For the `Crawler` class, read [the DomCrawler documentation](https://symfony.com/doc/current/components/dom_crawler.html)
-* For WebDriver, read [the Facebook PHP WebDriver documentation](https://github.com/facebook/php-webdriver)
+* For WebDriver, read [the PHP WebDriver documentation](https://github.com/php-webdriver/php-webdriver)
 
 ### Environment Variables
 
@@ -461,4 +461,4 @@ If you like this software, help save the (real) panthers by [donating to the Pan
 
 Created by [Kévin Dunglas](https://dunglas.fr). Sponsored by [Les-Tilleuls.coop](https://les-tilleuls.coop).
 
-Panther is built on top of [PHP WebDriver](https://github.com/facebook/php-webdriver) and [several other FOSS libraries](https://symfony.com/blog/introducing-symfony-panther-a-browser-testing-and-web-scrapping-library-for-php#thank-you-open-source). It has been inspired by [Nightwatch.js](http://nightwatchjs.org/), a WebDriver-based testing tool for JavaScript.
+Panther is built on top of [PHP WebDriver](https://github.com/php-webdriver/php-webdriver) and [several other FOSS libraries](https://symfony.com/blog/introducing-symfony-panther-a-browser-testing-and-web-scrapping-library-for-php#thank-you-open-source). It has been inspired by [Nightwatch.js](http://nightwatchjs.org/), a WebDriver-based testing tool for JavaScript.

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "require": {
     "php": ">=7.1",
-    "facebook/webdriver": "^1.7.1",
+    "php-webdriver/webdriver": "^1.7.1",
     "symfony/browser-kit": "^4.3 || ^5.0",
     "symfony/dom-crawler": "^4.3 || ^5.0",
     "symfony/http-client": "^4.3 || ^5.0",

--- a/src/WebDriver/WebDriverCheckbox.php
+++ b/src/WebDriver/WebDriverCheckbox.php
@@ -25,13 +25,13 @@ use Facebook\WebDriver\WebDriverSelectInterface;
 /**
  * Provides helper methods for checkboxes and radio buttons.
  *
- * This class has been proposed to facebook/php-webdriver and will be deleted from this project when it will me merged.
+ * This class has been proposed to php-webdriver/php-webdriver and will be deleted from this project when it will me merged.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
  * @internal
  *
- * @see https://github.com/facebook/php-webdriver/pull/545
+ * @see https://github.com/php-webdriver/php-webdriver/pull/545
  */
 class WebDriverCheckbox implements WebDriverSelectInterface
 {


### PR DESCRIPTION
Php-webdriver package [has been renamed](https://github.com/php-webdriver/php-webdriver/issues/730#issuecomment-575601572) and the original is now marked as abandoned.