### PR TITLE
Pass custom env to webserver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ CHANGELOG
 
 * Upgrade ChromeDriver to version 79.0.3945.36
 * Allow to pass custom timeouts as options of `ChromeManager` (`connection_timeout_in_ms` and `request_timeout_in_ms`)
-* Allow to pass custom env vars to `WebServerManager`
 
 0.6.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
 
 * Upgrade ChromeDriver to version 79.0.3945.36
 * Allow to pass custom timeouts as options of `ChromeManager` (`connection_timeout_in_ms` and `request_timeout_in_ms`)
+* Allow to pass custom env vars to `WebServerManager`
 
 0.6.0
 -----

--- a/src/ProcessManager/WebServerManager.php
+++ b/src/ProcessManager/WebServerManager.php
@@ -71,6 +71,11 @@ final class WebServerManager
             null,
             null
         );
+
+        // Symfony Process 3.4 BC: In newer versions env variables always inherit
+        if(is_callable([$this->process, 'inheritEnvironmentVariables'])) {
+            $this->process->inheritEnvironmentVariables(true);
+        }
     }
 
     public function start(): void

--- a/src/ProcessManager/WebServerManager.php
+++ b/src/ProcessManager/WebServerManager.php
@@ -72,8 +72,9 @@ final class WebServerManager
             null
         );
 
-        // Symfony Process 3.4 BC: In newer versions env variables always inherit
-        if(is_callable([$this->process, 'inheritEnvironmentVariables'])) {
+        // Symfony Process 3.4 BC: In newer versions env variables always inherit,
+        // but in 4.4 inheritEnvironmentVariables is deprecated, but setOptions was removed
+        if (\is_callable([$this->process, 'inheritEnvironmentVariables']) && \is_callable([$this->process, 'setOptions'])) {
             $this->process->inheritEnvironmentVariables(true);
         }
     }

--- a/src/ProcessManager/WebServerManager.php
+++ b/src/ProcessManager/WebServerManager.php
@@ -35,7 +35,7 @@ final class WebServerManager
     /**
      * @throws \RuntimeException
      */
-    public function __construct(string $documentRoot, string $hostname, int $port, string $router = '', string $readinessPath = '', $env = null)
+    public function __construct(string $documentRoot, string $hostname, int $port, string $router = '', string $readinessPath = '', array $env = null)
     {
         $this->hostname = $hostname;
         $this->port = $port;
@@ -47,7 +47,7 @@ final class WebServerManager
         }
 
         if (isset($_SERVER['PANTHER_APP_ENV'])) {
-            if($env === null) {
+            if (null === $env) {
                 $env = [];
             }
             $env['APP_ENV'] = $_SERVER['PANTHER_APP_ENV'];

--- a/src/ProcessManager/WebServerManager.php
+++ b/src/ProcessManager/WebServerManager.php
@@ -35,7 +35,7 @@ final class WebServerManager
     /**
      * @throws \RuntimeException
      */
-    public function __construct(string $documentRoot, string $hostname, int $port, string $router = '', string $readinessPath = '')
+    public function __construct(string $documentRoot, string $hostname, int $port, string $router = '', string $readinessPath = '', $env = null)
     {
         $this->hostname = $hostname;
         $this->port = $port;
@@ -46,9 +46,11 @@ final class WebServerManager
             throw new \RuntimeException('Unable to find the PHP binary.');
         }
 
-        $env = null;
         if (isset($_SERVER['PANTHER_APP_ENV'])) {
-            $env = ['APP_ENV' => $_SERVER['PANTHER_APP_ENV']];
+            if($env === null) {
+                $env = [];
+            }
+            $env['APP_ENV'] = $_SERVER['PANTHER_APP_ENV'];
         }
 
         $this->process = new Process(

--- a/tests/ProcessManager/WebServerManagerTest.php
+++ b/tests/ProcessManager/WebServerManagerTest.php
@@ -45,4 +45,13 @@ class WebServerManagerTest extends TestCase
             $server1->quit();
         }
     }
+
+    public function testPassEnv()
+    {
+        $server = new WebServerManager(__DIR__.'/../fixtures/', '127.0.0.1', 1234, '', '', ['FOO' => 'bar']);
+        $server->start();
+        $this->assertStringContainsString('bar', (string) file_get_contents('http://127.0.0.1:1234/env.php?name=FOO'));
+
+        $server->quit();
+    }
 }

--- a/tests/ProcessManager/WebServerManagerTest.php
+++ b/tests/ProcessManager/WebServerManagerTest.php
@@ -54,4 +54,23 @@ class WebServerManagerTest extends TestCase
 
         $server->quit();
     }
+
+    public function testPassPantherAppEnv()
+    {
+        $value = isset($_SERVER['PANTHER_APP_ENV']) ? $_SERVER['PANTHER_APP_ENV'] : null; // store app env
+
+        $_SERVER['PANTHER_APP_ENV'] = 'dev';
+        $server = new WebServerManager(__DIR__.'/../fixtures/', '127.0.0.1', 1234);
+        $server->start();
+        $this->assertStringContainsString('dev', (string) file_get_contents('http://127.0.0.1:1234/env.php?name=APP_ENV'));
+
+        $server->quit();
+
+        // restore app env
+        if($value === null) {
+            unset($_SERVER['PANTHER_APP_ENV']);
+            return;
+        }
+        $_SERVER['PANTHER_APP_ENV'] = $value;
+    }
 }

--- a/tests/ProcessManager/WebServerManagerTest.php
+++ b/tests/ProcessManager/WebServerManagerTest.php
@@ -57,7 +57,7 @@ class WebServerManagerTest extends TestCase
 
     public function testPassPantherAppEnv()
     {
-        $value = isset($_SERVER['PANTHER_APP_ENV']) ? $_SERVER['PANTHER_APP_ENV'] : null; // store app env
+        $value = $_SERVER['PANTHER_APP_ENV'] ?? null; // store app env
 
         $_SERVER['PANTHER_APP_ENV'] = 'dev';
         $server = new WebServerManager(__DIR__.'/../fixtures/', '127.0.0.1', 1234);
@@ -67,8 +67,9 @@ class WebServerManagerTest extends TestCase
         $server->quit();
 
         // restore app env
-        if($value === null) {
+        if (null === $value) {
             unset($_SERVER['PANTHER_APP_ENV']);
+
             return;
         }
         $_SERVER['PANTHER_APP_ENV'] = $value;

--- a/tests/fixtures/env.php
+++ b/tests/fixtures/env.php
@@ -11,4 +11,8 @@
 
 declare(strict_types=1);
 
-echo $_ENV[$_GET['name']];
+if ('APP_ENV' === $_GET['name'] ?? null): ?>
+    <?=$_ENV['APP_ENV']; ?>
+<?php else: ?>
+    <?=$_ENV['FOO']; ?>
+<?php endif; ?>

--- a/tests/fixtures/env.php
+++ b/tests/fixtures/env.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * This file is part of the Panther project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+echo $_ENV[$_GET['name']];


### PR DESCRIPTION
Sometimes the webserver needs to run with custom env vars, than the one used by the current process.

* Allow to pass custom env vars to `WebServerManager`
* Add test to pass `PANTHER_APP_ENV` to Webserver