### PR TITLE
Replace Goutte with HttpBrowser

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,10 +141,11 @@ Two alternative clients are available:
 
 * The first directly manipulates the Symfony kernel provided by `WebTestCase`. It is the fastest client available,
   but it is only available for Symfony apps.
-* The second leverages the [Goutte](https://github.com/FriendsOfPHP/Goutte) web scraping library.
-  It is an intermediate between Symfony's and Panther's test clients. Goutte sends real HTTP requests. 
+* The second leverages Symfony's [HttpBrowser](https://symfony.com/doc/4.4/components/browser_kit.html#making-external-http-requests).
+  It is an intermediate between Symfony's kernel and Panther's test clients. HttpBrowser sends real HTTP requests using
+  Symfony's [HttpClient](https://symfony.com/doc/current/components/http_client.html) component.
   It is fast and is able to browse any webpage, not only the ones of the application under test.
-  However, Goutte doesn't support JavaScript and other advanced features because it is entirely written in PHP.
+  However, HttpBrowser doesn't support JavaScript and other advanced features because it is entirely written in PHP.
   This one is available even for non-Symfony apps!
 
 The fun part is that the 3 clients implement the exact same API, so you can switch from one to another just by calling

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
     "guzzlehttp/guzzle": "^6.3",
     "symfony/css-selector": "^3.4 || ^4.0 || ^5.0",
     "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0",
+    "symfony/mime": "^4.3 || ^5.0",
     "symfony/phpunit-bridge": "^4.3.3 || ^5.0"
   }
 }

--- a/src/DomCrawler/Field/FileFormField.php
+++ b/src/DomCrawler/Field/FileFormField.php
@@ -22,7 +22,9 @@ final class FileFormField extends BaseFileFormField
 {
     use FormFieldTrait;
 
-    /** @var array */
+    /**
+     * @var array
+     */
     protected $value;
 
     public function getValue()

--- a/src/WebTestAssertionsTrait.php
+++ b/src/WebTestAssertionsTrait.php
@@ -76,9 +76,7 @@ trait WebTestAssertionsTrait
         $kernel = static::bootKernel($options);
 
         try {
-            /**
-             * @var KernelBrowser
-             */
+            /** @var KernelBrowser $client */
             $client = $kernel->getContainer()->get('test.client');
         } catch (ServiceNotFoundException $e) {
             if (class_exists(KernelBrowser::class)) {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -142,9 +142,7 @@ JS
      */
     public function testFollowLink(callable $clientFactory, string $type): void
     {
-        /**
-         * @var AbstractBrowser
-         */
+        /** @var AbstractBrowser $client */
         $client = $clientFactory();
         $crawler = $client->request('GET', static::$baseUri.'/link.html');
         $link = $crawler->filter('#d2')->selectLink('E1')->link();
@@ -162,9 +160,7 @@ JS
      */
     public function testSubmitForm(callable $clientFactory, string $type): void
     {
-        /**
-         * @var AbstractBrowser
-         */
+        /** @var AbstractBrowser $client */
         $client = $clientFactory();
         $crawler = $client->request('GET', static::$baseUri.'/form.html');
         $form = $crawler->filter('form')->eq(0)->selectButton('OK')->form([
@@ -194,9 +190,7 @@ JS
      */
     public function testSubmitFormWithValues(callable $clientFactory, string $type): void
     {
-        /**
-         * @var AbstractBrowser
-         */
+        /** @var AbstractBrowser $client */
         $client = $clientFactory();
         $crawler = $client->request('GET', static::$baseUri.'/form.html');
         $form = $crawler->filter('form')->eq(0)->selectButton('OK')->form();
@@ -217,9 +211,7 @@ JS
      */
     public function testHistory(callable $clientFactory)
     {
-        /**
-         * @var AbstractBrowser
-         */
+        /** @var AbstractBrowser $client */
         $client = $clientFactory();
         $crawler = $client->request('GET', self::$baseUri.'/link.html');
         $this->assertSame(self::$baseUri.'/link.html', $crawler->getUri());
@@ -246,9 +238,7 @@ JS
      */
     public function testCookie(callable $clientFactory, string $type)
     {
-        /**
-         * @var AbstractBrowser
-         */
+        /** @var AbstractBrowser $client */
         $client = $clientFactory();
         $crawler = $client->request('GET', self::$baseUri.'/cookie.php');
         $this->assertSame('0', $crawler->filter('#barcelona')->text());

--- a/tests/DomCrawler/Field/ChoiceFormFieldTest.php
+++ b/tests/DomCrawler/Field/ChoiceFormFieldTest.php
@@ -30,7 +30,7 @@ class ChoiceFormFieldTest extends TestCase
         $crawler = $this->request($clientFactory, '/choice-form-field.html');
         $form = $crawler->filter('form')->form();
 
-        /** @var ChoiceFormField */
+        /** @var ChoiceFormField $field */
         $field = $form['select_selected_one'];
         $this->assertInstanceOf(ChoiceFormField::class, $field);
         $this->assertSame('20', $field->getValue());
@@ -44,7 +44,7 @@ class ChoiceFormFieldTest extends TestCase
         $crawler = $this->request($clientFactory, '/choice-form-field.html');
         $form = $crawler->filter('form')->form();
 
-        /** @var ChoiceFormField */
+        /** @var ChoiceFormField $field */
         $field = $form['select_selected_none'];
         $this->assertInstanceOf(ChoiceFormField::class, $field);
         $this->assertSame('', $field->getValue());
@@ -58,7 +58,7 @@ class ChoiceFormFieldTest extends TestCase
         $crawler = $this->request($clientFactory, '/choice-form-field.html');
         $form = $crawler->filter('form')->form();
 
-        /** @var ChoiceFormField */
+        /** @var ChoiceFormField $field */
         $field = $form['select_multiple_selected_one'];
         $this->assertInstanceOf(ChoiceFormField::class, $field);
         $this->assertSame(['20'], $field->getValue());
@@ -72,7 +72,7 @@ class ChoiceFormFieldTest extends TestCase
         $crawler = $this->request($clientFactory, '/choice-form-field.html');
         $form = $crawler->filter('form')->form();
 
-        /** @var ChoiceFormField */
+        /** @var ChoiceFormField $field */
         $field = $form['select_multiple_selected_multiple'];
         $this->assertInstanceOf(ChoiceFormField::class, $field);
         $this->assertSame(['20', '30'], $field->getValue());
@@ -86,7 +86,7 @@ class ChoiceFormFieldTest extends TestCase
         $crawler = $this->request($clientFactory, '/choice-form-field.html');
         $form = $crawler->filter('form')->form();
 
-        /** @var ChoiceFormField */
+        /** @var ChoiceFormField $field */
         $field = $form['select_multiple_selected_none'];
         $this->assertInstanceOf(ChoiceFormField::class, $field);
         $this->assertSame([], $field->getValue());
@@ -100,7 +100,7 @@ class ChoiceFormFieldTest extends TestCase
         $crawler = $this->request($clientFactory, '/choice-form-field.html');
         $form = $crawler->filter('form')->form();
 
-        /** @var ChoiceFormField */
+        /** @var ChoiceFormField $field */
         $field = $form['radio_checked'];
         $this->assertInstanceOf(ChoiceFormField::class, $field);
         $this->assertSame('i_am_checked', $field->getValue());
@@ -114,7 +114,7 @@ class ChoiceFormFieldTest extends TestCase
         $crawler = $this->request($clientFactory, '/choice-form-field.html');
         $form = $crawler->filter('form')->form();
 
-        /** @var ChoiceFormField */
+        /** @var ChoiceFormField $field */
         $field = $form['radio_non_checked'];
         $this->assertInstanceOf(ChoiceFormField::class, $field);
         $this->assertNull($field->getValue());
@@ -128,7 +128,7 @@ class ChoiceFormFieldTest extends TestCase
         $crawler = $this->request($clientFactory, '/choice-form-field.html');
         $form = $crawler->filter('form')->form();
 
-        /** @var ChoiceFormField */
+        /** @var ChoiceFormField $field */
         $field = $form['checkbox_checked'];
         $this->assertInstanceOf(ChoiceFormField::class, $field);
         $this->assertSame('i_am_checked', $field->getValue());
@@ -142,7 +142,7 @@ class ChoiceFormFieldTest extends TestCase
         $crawler = $this->request($clientFactory, '/choice-form-field.html');
         $form = $crawler->filter('form')->form();
 
-        /** @var ChoiceFormField */
+        /** @var ChoiceFormField $field */
         $field = $form['checkbox_multiple_checked'];
         $this->assertInstanceOf(ChoiceFormField::class, $field);
         // we need this one! but it's not working in goutte
@@ -160,7 +160,7 @@ class ChoiceFormFieldTest extends TestCase
         $crawler = $this->request($clientFactory, '/choice-form-field.html');
         $form = $crawler->filter('form')->form();
 
-        /** @var ChoiceFormField */
+        /** @var ChoiceFormField $field */
         $field = $form['checkbox_non_checked'];
         $this->assertInstanceOf(ChoiceFormField::class, $field);
         $this->assertNull($field->getValue());

--- a/tests/DomCrawler/Field/ChoiceFormFieldTest.php
+++ b/tests/DomCrawler/Field/ChoiceFormFieldTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Symfony\Component\Panther\Tests\DomCrawler\Field;
 
-use Goutte\Client;
 use Symfony\Component\DomCrawler\Field\ChoiceFormField;
+use Symfony\Component\Panther\Client as PantherClient;
 use Symfony\Component\Panther\Tests\TestCase;
 
 /**
@@ -145,9 +145,9 @@ class ChoiceFormFieldTest extends TestCase
         /** @var ChoiceFormField $field */
         $field = $form['checkbox_multiple_checked'];
         $this->assertInstanceOf(ChoiceFormField::class, $field);
-        // we need this one! but it's not working in goutte
-        if (Client::class === $type) {
-            $this->markTestSkipped('Goutte client only returns one value. Maybe a bug in goutte?');
+        // https://github.com/symfony/symfony/issues/26827
+        if (PantherClient::class !== $type) {
+            $this->markTestSkipped('The DomCrawler component doesn\'t support multiple fields with the same name');
         }
         $this->assertSame(['checked_one', 'checked_two'], $field->getValue());
     }

--- a/tests/DomCrawler/Field/FileFormFieldTest.php
+++ b/tests/DomCrawler/Field/FileFormFieldTest.php
@@ -42,7 +42,7 @@ class FileFormFieldTest extends TestCase
         $crawler = $this->request($clientFactory, '/file-form-field.html');
         $form = $crawler->filter('form')->form();
 
-        /** @var FileFormField */
+        /** @var FileFormField $fileFormField */
         $fileFormField = $form['file_upload'];
         $this->assertInstanceOf(FileFormField::class, $fileFormField);
         $fileFormField->upload($this->getUploadFilePath(self::$uploadFileName));
@@ -58,7 +58,7 @@ class FileFormFieldTest extends TestCase
         $crawler = $this->request($clientFactory, '/file-form-field.html');
         $form = $crawler->filter('form')->form();
 
-        /** @var FileFormField */
+        /** @var FileFormField $fileFormField */
         $fileFormField = $form['file_upload'];
         $this->assertInstanceOf(FileFormField::class, $fileFormField);
         $fileFormField->setValue($this->getUploadFilePath(self::$uploadFileName));
@@ -76,7 +76,7 @@ class FileFormFieldTest extends TestCase
         $crawler = $this->request($clientFactory, '/file-form-field.html');
         $form = $crawler->filter('form')->form();
 
-        /** @var FileFormField */
+        /** @var FileFormField $fileFormField */
         $fileFormField = $form['file_upload'];
         $this->assertInstanceOf(FileFormField::class, $fileFormField);
 
@@ -95,7 +95,7 @@ class FileFormFieldTest extends TestCase
         $crawler = $this->request($clientFactory, '/file-form-field.html');
         $form = $crawler->filter('form')->form();
 
-        /** @var FileFormField */
+        /** @var FileFormField $fileFormField */
         $fileFormField = $form['file_upload'];
         $this->assertInstanceOf(FileFormField::class, $fileFormField);
 
@@ -120,7 +120,7 @@ class FileFormFieldTest extends TestCase
         $crawler = $this->request($clientFactory, '/file-form-field.html');
         $form = $crawler->filter('form')->form();
 
-        /** @var FileFormField */
+        /** @var FileFormField $fileFormField */
         $fileFormField = $form['file_upload'];
         $this->assertInstanceOf(FileFormField::class, $fileFormField);
 

--- a/tests/DomCrawler/Field/InputFormFieldTest.php
+++ b/tests/DomCrawler/Field/InputFormFieldTest.php
@@ -29,7 +29,7 @@ class InputFormFieldTest extends TestCase
         $crawler = $this->request($clientFactory, '/input-form-field.html');
         $form = $crawler->filter('form')->form();
 
-        /** @var InputFormField */
+        /** @var InputFormField $field */
         $field = $form['text_input_with_some_value'];
         $this->assertInstanceOf(InputFormField::class, $field);
         $this->assertSame('some_value', $field->getValue());
@@ -43,7 +43,7 @@ class InputFormFieldTest extends TestCase
         $crawler = $this->request($clientFactory, '/input-form-field.html');
         $form = $crawler->filter('form')->form();
 
-        /** @var InputFormField */
+        /** @var InputFormField $field */
         $field = $form['text_input_with_no_value'];
         $this->assertInstanceOf(InputFormField::class, $field);
         $this->assertSame('', $field->getValue());
@@ -57,7 +57,7 @@ class InputFormFieldTest extends TestCase
         $crawler = $this->request($clientFactory, '/input-form-field.html');
         $form = $crawler->filter('form')->form();
 
-        /** @var InputFormField */
+        /** @var InputFormField $field */
         $field = $form['text_input_with_no_value'];
         $this->assertInstanceOf(InputFormField::class, $field);
 

--- a/tests/DomCrawler/Field/TextareaFormFieldTest.php
+++ b/tests/DomCrawler/Field/TextareaFormFieldTest.php
@@ -29,7 +29,7 @@ class TextareaFormFieldTest extends TestCase
         $crawler = $this->request($clientFactory, '/textarea-form-field.html');
         $form = $crawler->filter('form')->form();
 
-        /** @var TextareaFormField */
+        /** @var TextareaFormField $field */
         $field = $form['textarea_with_some_value'];
         $this->assertInstanceOf(TextareaFormField::class, $field);
         $this->assertSame('some_value', $field->getValue());
@@ -43,7 +43,7 @@ class TextareaFormFieldTest extends TestCase
         $crawler = $this->request($clientFactory, '/textarea-form-field.html');
         $form = $crawler->filter('form')->form();
 
-        /** @var TextareaFormField */
+        /** @var TextareaFormField $field */
         $field = $form['textarea_with_no_value'];
         $this->assertInstanceOf(TextareaFormField::class, $field);
         $this->assertSame('', $field->getValue());
@@ -57,7 +57,7 @@ class TextareaFormFieldTest extends TestCase
         $crawler = $this->request($clientFactory, '/textarea-form-field.html');
         $form = $crawler->filter('form')->form();
 
-        /** @var TextareaFormField */
+        /** @var TextareaFormField $field */
         $field = $form['textarea_with_no_value'];
         $this->assertInstanceOf(TextareaFormField::class, $field);
 

--- a/tests/DomCrawler/FormTest.php
+++ b/tests/DomCrawler/FormTest.php
@@ -79,18 +79,14 @@ class FormTest extends TestCase
 
         $form = $crawler->filter('#another-form')->form();
 
-        /**
-         * @var ChoiceFormField
-         */
+        /** @var ChoiceFormField $j3 */
         $j3 = $form['j3'];
         $j3->select('j3a');
 
         $originalValues = $form->getValues();
         unset($originalValues['single-cb']);
 
-        /**
-         * @var ChoiceFormField
-         */
+        /** @var ChoiceFormField $singleCb */
         $singleCb = $form['single-cb'];
         $singleCb->tick();
         $this->assertSame($originalValues + ['single-cb' => 'hello'], $form->getValues());
@@ -111,15 +107,11 @@ class FormTest extends TestCase
         $form['i2']->setValue('Бакунин');
         $form['i3']->setValue('Ferrer');
 
-        /**
-         * @var ChoiceFormField
-         */
+        /** @var ChoiceFormField $i4 */
         $i4 = $form['i4'];
         $i4->select('i4b');
 
-        /**
-         * @var ChoiceFormField
-         */
+        /** @var ChoiceFormField $i5 */
         $i5 = $form['i5'];
         $i5->select(['i5b', 'i5c']);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Symfony\Component\Panther\Tests;
 
 use Goutte\Client as GoutteClient;
+use Symfony\Component\BrowserKit\HttpBrowser as HttpBrowserClient;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Panther\Client as PantherClient;
 use Symfony\Component\Panther\PantherTestCase;
@@ -45,14 +46,15 @@ abstract class TestCase extends PantherTestCase
     {
         // Tests must pass with both Panther and Goutte
         return [
-            [[static::class, 'createGoutteClient'], GoutteClient::class],
-            [[static::class, 'createPantherClient'], PantherClient::class],
+            'Goutte' => [[static::class, 'createGoutteClient'], GoutteClient::class],
+            'HttpBrowser' => [[static::class, 'createHttpBrowserClient'], HttpBrowserClient::class],
+            'Panther' => [[static::class, 'createPantherClient'], PantherClient::class],
         ];
     }
 
     protected function request(callable $clientFactory, string $path): Crawler
     {
-        return $clientFactory()->request('GET', $path);
+        return $clientFactory()->request('GET', self::$baseUri.$path);
     }
 
     protected function getUploadFilePath(string $fileName): string


### PR DESCRIPTION
It seems that Goutte is being replaced by Symfony's HttpBrowser. This is evident due to the fact that the latest version of Goutte actually only [extends HttpBrowser](https://github.com/FriendsOfPHP/Goutte/blob/v4.0.0/Goutte/Client.php#L19) without adding any additional functionality to it.

This PR deprecates Goutte in favor of Symfony's HttpBrowser.