### PR TITLE
Fix an issue when one uses only the PantherTestCaseTrait

### DIFF
--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -80,7 +80,7 @@ trait PantherTestCaseTrait
         'router' => '',
         'external_base_uri' => null,
         'readinessPath' => '',
-        'browser' => self::CHROME,
+        'browser' => PantherTestCase::CHROME,
     ];
 
     public static function tearDownAfterClass(): void
@@ -167,7 +167,7 @@ trait PantherTestCaseTrait
 
         self::startWebServer($options);
 
-        if (self::CHROME === ($options['browser'] ?? self::$defaultOptions['browser'] ?? self::CHROME)) {
+        if (PantherTestCase::CHROME === ($options['browser'] ?? self::$defaultOptions['browser'] ?? PantherTestCase::CHROME)) {
             self::$pantherClients[0] = self::$pantherClient = Client::createChromeClient(null, null, [], self::$baseUri);
         } else {
             self::$pantherClients[0] = self::$pantherClient = Client::createFirefoxClient(null, null, [], self::$baseUri);


### PR DESCRIPTION
On a project I just use the trait without the full test case, and if so, the  `self::CHROME` instruction throws an error since this constant is defined in the full test case.