### PR TITLE
Added recommended flag to Docker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ FROM php:latest
 
 RUN apt-get update && apt-get install -y libzip-dev zlib1g-dev chromium && docker-php-ext-install zip
 ENV PANTHER_NO_SANDBOX 1
+ENV PANTHER_CHROME_ARGUMENTS='--disable-dev-shm-usage' # Not mandatory, but recommended
 ```
 
 Build it with `docker build . -t myproject`

--- a/README.md
+++ b/README.md
@@ -319,7 +319,8 @@ FROM php:latest
 
 RUN apt-get update && apt-get install -y libzip-dev zlib1g-dev chromium && docker-php-ext-install zip
 ENV PANTHER_NO_SANDBOX 1
-ENV PANTHER_CHROME_ARGUMENTS='--disable-dev-shm-usage' # Not mandatory, but recommended
+# Not mandatory, but recommended
+ENV PANTHER_CHROME_ARGUMENTS='--disable-dev-shm-usage'
 ```
 
 Build it with `docker build . -t myproject`


### PR DESCRIPTION
Hello,

As per [Google recommendations](https://developers.google.com/web/tools/puppeteer/troubleshooting#tips), `--disable-dev-shm-usage` flag is recommended for running Google Chrome inside Docker containers. I added it to Docker `README.md` example, as it is easy to forget about.
