### PR TITLE
Add explicit fail on web driver binary file issue

### DIFF
--- a/src/ProcessManager/ChromeManager.php
+++ b/src/ProcessManager/ChromeManager.php
@@ -33,7 +33,12 @@ final class ChromeManager implements BrowserManagerInterface
     public function __construct(?string $chromeDriverBinary = null, ?array $arguments = null, array $options = [])
     {
         $this->options = array_merge($this->getDefaultOptions(), $options);
-        $this->process = new Process([$chromeDriverBinary ?: $this->findChromeDriverBinary(), '--port='.$this->options['port']], null, null, null, null);
+
+        $chromeDriverBinary = $chromeDriverBinary ?: $this->findChromeDriverBinary();
+
+        $this->checkWebDriverBinary($chromeDriverBinary, 'chrome');
+
+        $this->process = new Process([$chromeDriverBinary, '--port='.$this->options['port']], null, null, null, null);
         $this->arguments = $arguments ?? $this->getDefaultArguments();
     }
 

--- a/src/ProcessManager/FirefoxManager.php
+++ b/src/ProcessManager/FirefoxManager.php
@@ -32,7 +32,12 @@ final class FirefoxManager implements BrowserManagerInterface
     public function __construct(?string $geckodriverBinary = null, ?array $arguments = null, array $options = [])
     {
         $this->options = array_merge($this->getDefaultOptions(), $options);
-        $this->process = new Process([$geckodriverBinary ?: $this->findGeckodriverBinary(), '--port='.$this->options['port']], null, null, null, null);
+
+        $geckodriverBinary = $geckodriverBinary ?: $this->findGeckodriverBinary();
+
+        $this->checkWebDriverBinary($geckodriverBinary, 'firefox');
+
+        $this->process = new Process([$geckodriverBinary, '--port='.$this->options['port']], null, null, null, null);
         $this->arguments = $arguments ?? $this->getDefaultArguments();
     }
 

--- a/src/ProcessManager/WebServerReadinessProbeTrait.php
+++ b/src/ProcessManager/WebServerReadinessProbeTrait.php
@@ -38,6 +38,16 @@ trait WebServerReadinessProbeTrait
         }
     }
 
+    /**
+     * @throws \RuntimeException
+     */
+    private function checkWebDriverBinary(string $webDriverBinary, string $service): void
+    {
+        if (!is_executable($webDriverBinary)) {
+            throw new \RuntimeException("Could not start $service, web driver binary $webDriverBinary is not executable.");
+        }
+    }
+
     public function waitUntilReady(Process $process, string $url, string $service, bool $allowNotOkStatusCode = false, int $timeout = 30): void
     {
         $client = HttpClient::create(['timeout' => $timeout]);


### PR DESCRIPTION
Chrome and Firefox Process Managers are throwing `\RuntimeException` _(in waitUntilReady)_  after 30s when web driver binary file is not an executable file.
I suggest this explanative exception instead.