### PR TITLE
CHROME & FIREFOX constant late static binding

### DIFF
--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -168,7 +168,7 @@ trait PantherTestCaseTrait
             $browserManager = self::$pantherClient->getBrowserManager();
             if (
                 (static::CHROME === $browser && $browserManager instanceof ChromeManager) ||
-                (self::FIREFOX === $browser && $browserManager instanceof FirefoxManager)
+                (static::FIREFOX === $browser && $browserManager instanceof FirefoxManager)
             ) {
                 return $callGetClient ? self::getClient(self::$pantherClient) : self::$pantherClient;
             }

--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -162,12 +162,12 @@ trait PantherTestCaseTrait
      */
     protected static function createPantherClient(array $options = [], array $kernelOptions = [], array $managerOptions = []): PantherClient
     {
-        $browser = ($options['browser'] ?? self::$defaultOptions['browser'] ?? self::CHROME);
+        $browser = ($options['browser'] ?? self::$defaultOptions['browser'] ?? static::CHROME);
         $callGetClient = \is_callable([self::class, 'getClient']) && (new \ReflectionMethod(self::class, 'getClient'))->isStatic();
         if (null !== self::$pantherClient) {
             $browserManager = self::$pantherClient->getBrowserManager();
             if (
-                (self::CHROME === $browser && $browserManager instanceof ChromeManager) ||
+                (static::CHROME === $browser && $browserManager instanceof ChromeManager) ||
                 (self::FIREFOX === $browser && $browserManager instanceof FirefoxManager)
             ) {
                 return $callGetClient ? self::getClient(self::$pantherClient) : self::$pantherClient;
@@ -176,7 +176,7 @@ trait PantherTestCaseTrait
 
         self::startWebServer($options);
 
-        if (self::CHROME === $browser) {
+        if (static::CHROME === $browser) {
             self::$pantherClients[0] = self::$pantherClient = Client::createChromeClient(null, null, $managerOptions, self::$baseUri);
         } else {
             self::$pantherClients[0] = self::$pantherClient = Client::createFirefoxClient(null, null, $managerOptions, self::$baseUri);


### PR DESCRIPTION
**Context:**
I would like to be able to set the `const CHROME` constant anywhere in the inheritance while using the `PantherTestCaseTrait`.

**Example:**
```php
class CustomPanther extends PantherDriver
{
    const CHROME = 'chrome';
}

class PantherDriver
{
    use PantherTestCaseTrait;
}
```
**Error**
Fatal error: Undefined class constant 'CHROME'

**Solution:**
Be able to set the CHROME constant from the child classes, using **late static bindings**.