### PR TITLE
Improve error message when the web server crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Since Panther implements the API of popular libraries, it already has extensive 
 The following environment variables can be set to change some Panther's behaviour:
 
 * `PANTHER_NO_HEADLESS`: to disable browser's headless mode (will display the testing window, useful to debug)
-* `PANTHER_WEB_SERVER_DIR`: to change the project's document root (default to `public/`)
+* `PANTHER_WEB_SERVER_DIR`: to change the project's document root (default to `./public/`, relative paths **must start** by `./`)
 * `PANTHER_WEB_SERVER_PORT`: to change the web server's port (default to `9080`)
 * `PANTHER_WEB_SERVER_ROUTER`:  to use a web server router script which is run at the start of each HTTP request
 * `PANTHER_EXTERNAL_BASE_URI`: to use an external web server (the PHP built-in web server will not be started)

--- a/src/ProcessManager/WebServerReadinessProbeTrait.php
+++ b/src/ProcessManager/WebServerReadinessProbeTrait.php
@@ -46,14 +46,8 @@ trait WebServerReadinessProbeTrait
 
         while (true) {
             $status = $process->getStatus();
-            if ($status === Process::STATUS_TERMINATED) {
-                throw new \RuntimeException(sprintf(
-                    'Could not start %s. Exit code: %d (%s). Error output: %s',
-                    $service,
-                    $process->getExitCode(),
-                    $process->getExitCodeText(),
-                    $process->getErrorOutput()
-                ));
+            if (Process::STATUS_TERMINATED === $status) {
+                throw new \RuntimeException(sprintf('Could not start %s. Exit code: %d (%s). Error output: %s', $service, $process->getExitCode(), $process->getExitCodeText(), $process->getErrorOutput()));
             }
 
             if (Process::STATUS_STARTED !== $status) {

--- a/src/ProcessManager/WebServerReadinessProbeTrait.php
+++ b/src/ProcessManager/WebServerReadinessProbeTrait.php
@@ -46,6 +46,16 @@ trait WebServerReadinessProbeTrait
 
         while (true) {
             $status = $process->getStatus();
+            if ($status === Process::STATUS_TERMINATED) {
+                throw new \RuntimeException(sprintf(
+                    'Could not start %s. Exit code: %d (%s). Error output: %s',
+                    $service,
+                    $process->getExitCode(),
+                    $process->getExitCodeText(),
+                    $process->getErrorOutput()
+                ));
+            }
+
             if (Process::STATUS_STARTED !== $status) {
                 if (microtime(true) - $start >= $timeout) {
                     throw new \RuntimeException("Could not start $service (or it crashed) after $timeout seconds.");

--- a/tests/ProcessManager/WebServerManagerTest.php
+++ b/tests/ProcessManager/WebServerManagerTest.php
@@ -74,4 +74,17 @@ class WebServerManagerTest extends TestCase
         }
         $_SERVER['PANTHER_APP_ENV'] = $value;
     }
+
+    public function testInvalidDocumentRoot(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageRegExp('#/not-exists#');
+
+        try {
+            $server = new WebServerManager('/not-exists', '127.0.0.1', 1234);
+            $server->start();
+        } finally {
+            $server->quit();
+        }
+    }
 }


### PR DESCRIPTION
Before:

    RuntimeException: Could not start web server (or it crashed) after 30 seconds.

After:

    RuntimeException: Could not start web server. Exit code: 1 (General error). Error output: Directory tests/Application/public does not exist.
