### PR TITLE
fix email field with existing value

### DIFF
--- a/src/DomCrawler/Field/InputFormField.php
+++ b/src/DomCrawler/Field/InputFormField.php
@@ -24,7 +24,7 @@ final class InputFormField extends BaseInputFormField
 
     public function setValue($value)
     {
-        if (\in_array($this->element->getAttribute('type'), ['text'], true)) {
+        if (\in_array($this->element->getAttribute('type'), ['text', 'email'], true)) {
             $this->setTextValue($value);
         } elseif (\is_bool($value)) {
             $this->element->click();

--- a/src/DomCrawler/Field/InputFormField.php
+++ b/src/DomCrawler/Field/InputFormField.php
@@ -24,7 +24,7 @@ final class InputFormField extends BaseInputFormField
 
     public function setValue($value)
     {
-        if (\in_array($this->element->getAttribute('type'), ['text', 'email'], true)) {
+        if (\in_array($this->element->getAttribute('type'), ['text', 'email', 'number'], true)) {
             $this->setTextValue($value);
         } elseif (\is_bool($value)) {
             $this->element->click();

--- a/tests/DomCrawler/Field/EmailInputFormFieldTest.php
+++ b/tests/DomCrawler/Field/EmailInputFormFieldTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Panther project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Panther\Tests\DomCrawler\Field;
+
+use Symfony\Component\DomCrawler\Field\InputFormField;
+use Symfony\Component\Panther\Tests\TestCase;
+
+/**
+ * @author Dominik Pfaffenbauer <dominik@pfaffenbauer.at>
+ */
+class EmailInputFormFieldTest extends TestCase
+{
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testGetValueWithSomeValueFromTextInput(callable $clientFactory)
+    {
+        $crawler = $this->request($clientFactory, '/input-email-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var InputFormField $field */
+        $field = $form['text_input_with_some_value'];
+        $this->assertInstanceOf(InputFormField::class, $field);
+        $this->assertSame('some_value', $field->getValue());
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testGetValueWithNoValueFromTextInput(callable $clientFactory)
+    {
+        $crawler = $this->request($clientFactory, '/input-email-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var InputFormField $field */
+        $field = $form['text_input_with_no_value'];
+        $this->assertInstanceOf(InputFormField::class, $field);
+        $this->assertSame('', $field->getValue());
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testSetValueMultipleTimesInTextInput(callable $clientFactory)
+    {
+        $crawler = $this->request($clientFactory, '/input-email-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var InputFormField $field */
+        $field = $form['text_input_with_no_value'];
+        $this->assertInstanceOf(InputFormField::class, $field);
+
+        $field->setValue('first@example.com');
+        $this->assertSame('first@example.com', $field->getValue());
+
+        $field->setValue('second@example.com');
+        $this->assertSame('second@example.com', $field->getValue());
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testChangeValueFromExistingValue(callable $clientFactory)
+    {
+        $crawler = $this->request($clientFactory, '/input-email-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var InputFormField $field */
+        $field = $form['text_input_with_some_value'];
+        $this->assertInstanceOf(InputFormField::class, $field);
+
+        $field->setValue('first@example.com');
+        $this->assertSame('first@example.com', $field->getValue());
+    }
+}

--- a/tests/DomCrawler/Field/NumberInputFormFieldTest.php
+++ b/tests/DomCrawler/Field/NumberInputFormFieldTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Panther project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Panther\Tests\DomCrawler\Field;
+
+use Symfony\Component\DomCrawler\Field\InputFormField;
+use Symfony\Component\Panther\Tests\TestCase;
+
+/**
+ * @author Dominik Pfaffenbauer <dominik@pfaffenbauer.at>
+ */
+class NumberInputFormFieldTest extends TestCase
+{
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testGetValueWithSomeValueFromTextInput(callable $clientFactory)
+    {
+        $crawler = $this->request($clientFactory, '/input-number-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var InputFormField $field */
+        $field = $form['number_input_with_some_value'];
+        $this->assertInstanceOf(InputFormField::class, $field);
+        $this->assertSame('10', $field->getValue());
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testGetValueWithNoValueFromTextInput(callable $clientFactory)
+    {
+        $crawler = $this->request($clientFactory, '/input-number-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var InputFormField $field */
+        $field = $form['number_input_with_no_value'];
+        $this->assertInstanceOf(InputFormField::class, $field);
+        $this->assertSame('', $field->getValue());
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testSetValueMultipleTimesInTextInput(callable $clientFactory)
+    {
+        $crawler = $this->request($clientFactory, '/input-number-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var InputFormField $field */
+        $field = $form['number_input_with_no_value'];
+        $this->assertInstanceOf(InputFormField::class, $field);
+
+        $field->setValue('10');
+        $this->assertSame('10', $field->getValue());
+
+        $field->setValue('30');
+        $this->assertSame('30', $field->getValue());
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testChangeValueFromExistingValue(callable $clientFactory)
+    {
+        $crawler = $this->request($clientFactory, '/input-number-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var InputFormField $field */
+        $field = $form['number_input_with_some_value'];
+        $this->assertInstanceOf(InputFormField::class, $field);
+
+        $field->setValue('15');
+        $this->assertSame('15', $field->getValue());
+    }
+}

--- a/tests/fixtures/input-email-form-field.html
+++ b/tests/fixtures/input-email-form-field.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Form with InputFormField</title>
+    <style>
+        label {
+            border: 1px solid lightgrey;
+            display: block;
+        }
+    </style>
+</head>
+<body>
+<form>
+
+    <label class="field">
+        text_input_with_some_value
+        <input name="text_input_with_some_value" type="email" value="some_value" />
+    </label>
+
+    <label class="field">
+        text_input_with_no_value
+        <input name="text_input_with_no_value" type="email" />
+    </label>
+
+    <input type="submit" value="OK">
+</form>
+</body>
+</html>

--- a/tests/fixtures/input-number-form-field.html
+++ b/tests/fixtures/input-number-form-field.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Form with InputFormField</title>
+    <style>
+        label {
+            border: 1px solid lightgrey;
+            display: block;
+        }
+    </style>
+</head>
+<body>
+<form>
+
+    <label class="field">
+        number_input_with_some_value
+        <input name="number_input_with_some_value" type="number" value="10" />
+    </label>
+
+    <label class="field">
+        number_input_with_no_value
+        <input name="number_input_with_no_value" type="number" />
+    </label>
+
+    <input type="submit" value="OK">
+</form>
+</body>
+</html>


### PR DESCRIPTION
If an input field of type "email" already has a value, the field value is not reset, it's getting appended. this fixes it.