### PR TITLE
Single instruction to update driver

### DIFF
--- a/chromedriver-bin/update.sh
+++ b/chromedriver-bin/update.sh
@@ -2,6 +2,8 @@
 # Author: Kévin Dunglas <dunglas@gmail.com>
 # Download the last version of ChromeDriver binaries
 
+cd "$(dirname "$0")"
+
 latest=$(curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE)
 
 echo "Downloading ChromeDriver version ${latest}..."

--- a/geckodriver-bin/update.sh
+++ b/geckodriver-bin/update.sh
@@ -2,6 +2,8 @@
 # Author: Kévin Dunglas <dunglas@gmail.com>
 # Download the last version of geckodriver binaries
 
+cd "$(dirname "$0")"
+
 latest=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq -r '.tag_name')
 
 echo "Downloading geckodriver version ${latest}..."


### PR DESCRIPTION
My travis test fail sometimes, because i don't have the latest version of the chrome driver.

``This version of ChromeDriver only supports Chrome version 80``

So i want to execute the update scripts for the binaries before i execute my scripts.

``
./vendor/symfony/panther/chromedriver-bin/update.sh
``

But they will install everything in my project directory. I know i can use ``cd`` the go in the directory first. But i think this line makes it more nice to use this script.

I also just thinking to avoid this kind of error and to prevent executable pollution in this repository, by update this binaries if they don't exists (First use of panther). And if some driver version problem occurs, just provide this script by adding some information about it to the readme. Just let me know what you think. I could create further PR.
