### PR TITLE
Guess installed version for chromedriver update

### DIFF
--- a/chromedriver-bin/update.sh
+++ b/chromedriver-bin/update.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 # Author: Kévin Dunglas <dunglas@gmail.com>
-# Download the last version of ChromeDriver binaries
+# Download the last compatible version of ChromeDriver binaries, falling back to last version
 
-latest=$(curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE)
+current=$(chromium --product-version)
+if [[ ${current} == *"."* ]]; then
+   current="_$( cut -d '.' -f 1 <<< "$current" )";
+else
+  current=''
+fi
+
+latest=$(curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE${current})
 
 echo "Downloading ChromeDriver version ${latest}..."
 


### PR DESCRIPTION
From time to time I get stucked with version mismatch of chromedriver and chromium.

E.g. now on 22.06.2020 the latest chromedriver version is 83 and the chromium version installed with debian default repositories is 80.
See: https://packages.debian.org/buster/chromium -> it's "chromium (80.0.3987.162-1~deb10u1)"
So the update script is useless at the moment (at least for my setup).

This PR is guessing installed version of installed chromium version and downloading corresponding chromedriver version. Also see https://sites.google.com/a/chromium.org/chromedriver/downloads/version-selection
If the guessing fails for any reason then it falls back to the "old" logic downloading latest chromedriver version.

Another advantage is that it is up to the user when he wants to update his chromium and chromedriver.