### PR TITLE
Disable process output to stop timeout error

### DIFF
--- a/src/ProcessManager/WebServerManager.php
+++ b/src/ProcessManager/WebServerManager.php
@@ -71,6 +71,8 @@ final class WebServerManager
             null,
             null
         );
+        // Stop Operation timed out after 30001 milliseconds with 0 bytes received errors
+        $this->process->disableOutput();
 
         // Symfony Process 3.4 BC: In newer versions env variables always inherit,
         // but in 4.4 inheritEnvironmentVariables is deprecated, but setOptions was removed


### PR DESCRIPTION
"Operation timed out after 30000 milliseconds with 0 bytes received"

I was getting this error when running all tests that use Panther.

After some trial and error i found that disabling the output for the process created by WebServerManager seemed to resolve the issue.

If i run each test individually or a small selection i don't get this error.

**Update**
After some testing it appear that the issue is caused but the stderr pipe not being emptied. This is then causing the php server process to lock up. You can either empty the stderr pipe or set it to `fopen('/dev/null', 'c')` to remedy the situation.

This change will not affect anything as only the status of the process is queried.
