### PR TITLE
Disable web server process output to stop operation timeout

### DIFF
--- a/src/ProcessManager/WebServerManager.php
+++ b/src/ProcessManager/WebServerManager.php
@@ -71,6 +71,7 @@ final class WebServerManager
             null,
             null
         );
+        $this->process->disableOutput();
 
         // Symfony Process 3.4 BC: In newer versions env variables always inherit,
         // but in 4.4 inheritEnvironmentVariables is deprecated, but setOptions was removed


### PR DESCRIPTION
This PR disables the output from the web server process to stop operation time-outs happening. The web server process is locking as the stderr pipe is not getting emptied.

fixes #364 