### PR TITLE
Fix baseUri not taken into account when using Symfony HttpBrowser

### DIFF
--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -245,6 +245,12 @@ trait PantherTestCaseTrait
             static::bootKernel($kernelOptions); // @phpstan-ignore-line
         }
 
+        $urlComponents = parse_url(self::$baseUri);
+        self::$httpBrowserClient->setServerParameter('HTTP_HOST', sprintf('%s:%s', $urlComponents['host'], $urlComponents['port']));
+        if ('https' === $urlComponents['scheme']) {
+            self::$httpBrowserClient->setServerParameter('HTTPS', 'true');
+        }
+
         return self::$httpBrowserClient;
     }
 


### PR DESCRIPTION
By default, HttpBrowser expects absolute URLs, but this makes tests interoperability almost impossible.
However, it is possible to tell HttpBrowser to use a given host, by setting the `HTTP_HOST` server variable, in conjunction with `HTTPS` if applicable.

This change ensures that `self::$baseUri` is correctly taken into
account in this regard.

Should fix #313
