### PR TITLE
Fix symfony/phpunit-bridge version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,6 @@
     "symfony/css-selector": "^4.4 || ^5.0",
     "symfony/framework-bundle": "^4.4 || ^5.0",
     "symfony/mime": "^4.4 || ^5.0",
-    "symfony/phpunit-bridge": "dev-master"
+    "symfony/phpunit-bridge": "5.x-dev"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,6 @@
     "symfony/css-selector": "^4.4 || ^5.0",
     "symfony/framework-bundle": "^4.4 || ^5.0",
     "symfony/mime": "^4.4 || ^5.0",
-    "symfony/phpunit-bridge": "5.x-dev"
+    "symfony/phpunit-bridge": "^5.1"
   }
 }


### PR DESCRIPTION
When trying to install panther locally I ended up with this composer error
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - The requested package symfony/phpunit-bridge dev-master exists as symfony/phpunit-bridge[2.7.x-dev, ..., v5.2.0-BETA1] but these are rejected by your constraint.
```

I found out that there is no more branch `master` on `symfony/phpunit-bridge` project but branch `5.x` is the default one now