### PR TITLE
Prevent PHP 8 from outputting fatal error when calling fsockopen()

### DIFF
--- a/src/ProcessManager/WebServerReadinessProbeTrait.php
+++ b/src/ProcessManager/WebServerReadinessProbeTrait.php
@@ -29,7 +29,10 @@ trait WebServerReadinessProbeTrait
      */
     private function checkPortAvailable(string $hostname, int $port, bool $throw = true): void
     {
-        $resource = @fsockopen($hostname, $port);
+        $current_state = error_reporting();
+        error_reporting(0);
+        $resource = fsockopen($hostname, $port);
+        error_reporting($current_state);
         if (\is_resource($resource)) {
             fclose($resource);
             if ($throw) {

--- a/src/ProcessManager/WebServerReadinessProbeTrait.php
+++ b/src/ProcessManager/WebServerReadinessProbeTrait.php
@@ -29,10 +29,10 @@ trait WebServerReadinessProbeTrait
      */
     private function checkPortAvailable(string $hostname, int $port, bool $throw = true): void
     {
-        $current_state = error_reporting();
+        $currentState = error_reporting();
         error_reporting(0);
         $resource = fsockopen($hostname, $port);
-        error_reporting($current_state);
+        error_reporting($currentState);
         if (\is_resource($resource)) {
             fclose($resource);
             if ($throw) {


### PR DESCRIPTION
Since PHP 8, @ Error Suppression operator does not silent fatal errors anymore.
See https://php.watch/versions/8.0/fatal-error-suppression for more.

This change prevent PHP 8 from outputting
Warning Error: fsockopen(): Unable to connect to 127.0.0.1:9515 (Connection refused)