### PR TITLE
Screenshot improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 /composer.phar
 /composer.lock
 /phpunit.xml
+/screenshots/
 /vendor/

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ The following environment variables can be set to change some Panther's behaviou
 * `PANTHER_WEB_SERVER_ROUTER`:  to use a web server router script which is run at the start of each HTTP request
 * `PANTHER_EXTERNAL_BASE_URI`: to use an external web server (the PHP built-in web server will not be started)
 * `PANTHER_APP_ENV`: to override the `APP_ENV` variable passed to the web server running the PHP app
+* `PANTHER_SCREENSHOT_DIR`: to set a base directory for your screenshots (ie `./screenshots`)
 
 #### Chrome-specific Environment Variables
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -436,6 +436,10 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
     {
         $this->start();
 
+        if ($saveAs && ($dir = $_SERVER['PANTHER_SCREENSHOT_DIR'] ?? false)) {
+            $saveAs = "{$dir}/{$saveAs}";
+        }
+
         return $this->webDriver->takeScreenshot($saveAs);
     }
 

--- a/tests/ScreenshotTest.php
+++ b/tests/ScreenshotTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Symfony\Component\Panther\Tests;
+
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+class ScreenshotTest extends TestCase
+{
+    private static $screenshotDir = __DIR__.'/../screenshots';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        (new Filesystem())->remove(self::$screenshotDir);
+    }
+
+    public function testTakeScreenshot(): void
+    {
+        $file = self::$screenshotDir.'/screenshot.jpg';
+
+        $this->assertFileDoesNotExist($file);
+
+        $client = self::createPantherClient();
+        $client->request('GET', '/basic.html');
+        $client->takeScreenshot($file);
+
+        $this->assertFileExists($file);
+    }
+}


### PR DESCRIPTION
This feature allow setting a base screenshot directory via the `PANTHER_SCREENSHOT_DIR` env variable. When this is set, you can exclude the absolute path when calling `$client->takeScreenshot()`.

Example, assuming the `PANTHER_SCREENSHOT_DIR` has been set to `./screenshots`:

```php
$client->takeScreenshot('about.png'); // saves to ./screenshots/about.png
$client->takeScreenshot('/contact.png'); // saves to ./screenshots/contact.png
```