### PR TITLE
[FIX] DomCrawler/Crawler.php throws "Required Param after Optional" Error in PHP8 #393

### DIFF
--- a/src/DomCrawler/Crawler.php
+++ b/src/DomCrawler/Crawler.php
@@ -34,7 +34,7 @@ final class Crawler extends BaseCrawler implements WebDriverElement
     /**
      * @param WebDriverElement[] $elements
      */
-    public function __construct(array $elements = [], WebDriver $webDriver, ?string $uri = null)
+    public function __construct(array $elements = null, WebDriver $webDriver, ?string $uri = null)
     {
         $this->uri = $uri;
         $this->webDriver = $webDriver;

--- a/src/DomCrawler/Crawler.php
+++ b/src/DomCrawler/Crawler.php
@@ -34,7 +34,7 @@ final class Crawler extends BaseCrawler implements WebDriverElement
     /**
      * @param WebDriverElement[] $elements
      */
-    public function __construct(array $elements = null, WebDriver $webDriver, ?string $uri = null)
+    public function __construct(array $elements = [], ?WebDriver $webDriver = null, ?string $uri = null)
     {
         $this->uri = $uri;
         $this->webDriver = $webDriver;


### PR DESCRIPTION
Change empty array default param to null to support PHP8 deprecation of non-null optional params.