### PR TITLE
feat: add future assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ class E2eTest extends PantherTestCase
         $this->assertSelectorWillBeEnabled('[type="submit"]'); // button will be enabled 
         $this->assertSelectorWillBeDisabled('[type="submit"]'); // button will be disabled 
         $this->assertSelectorAttributeWillContain('.price', 'data-old-price', '€25'); // attribute will contains content
-        $this->assertSelectorAttributeWillNotContain('.price', 'data-old-price', '25 €'); // attribute will not contain content
+        $this->assertSelectorAttributeWillNotContain('.price', 'data-old-price', '€25'); // attribute will not contain content
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ class E2eTest extends PantherTestCase
         $this->assertSelectorWillNotContain('.promotion', '5%'); // text will be removed from the element content
         $this->assertSelectorWillBeEnabled('[type="submit"]'); // button will be enabled 
         $this->assertSelectorWillBeDisabled('[type="submit"]'); // button will be disabled 
-        $this->assertSelectorAttributeWillContain('.price', 'data-old-price', '25 €'); // attribute will contains content
+        $this->assertSelectorAttributeWillContain('.price', 'data-old-price', '€25'); // attribute will contains content
         $this->assertSelectorAttributeWillNotContain('.price', 'data-old-price', '25 €'); // attribute will not contain content
     }
 }

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ class E2eTest extends PantherTestCase
         $client->waitForAttributeToContain('.price', 'data-old-price', '25 €'); // wait for the attribute to contain content
         $client->waitForAttributeToNotContain('.price', 'data-old-price', '25 €'); // wait for the attribute to not contain content
         
-        // Let's predict future
+        // Let's predict the future
         $this->assertSelectorWillExist('.popin'); // element will be attached to the DOM
         $this->assertSelectorWillNotExist('.popin'); // element will be removed from the DOM
         $this->assertSelectorWillBeVisible('.loader'); // element will be visible

--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ class E2eTest extends PantherTestCase
         $this->assertSelectorIsDisabled('[type="submit"]');
         $this->assertSelectorIsVisible('.errors');
         $this->assertSelectorIsNotVisible('.loading');
-        $this->assertSelectorAttributeToContain('.price', 'data-old-price', '42');
-        $this->assertSelectorAttributeToNotContain('.price', 'data-old-price', '36');
+        $this->assertSelectorAttributeContains('.price', 'data-old-price', '42');
+        $this->assertSelectorAttributeNotContains('.price', 'data-old-price', '36');
 
         // Use waitForX methods to wait until some asynchronous process finish
         $client->waitFor('.popin'); // wait for element to be attached to the DOM

--- a/README.md
+++ b/README.md
@@ -159,15 +159,32 @@ class E2eTest extends PantherTestCase
         $this->assertSelectorIsDisabled('[type="submit"]');
         $this->assertSelectorIsVisible('.errors');
         $this->assertSelectorIsNotVisible('.loading');
+        $this->assertSelectorAttributeToContain('.price', 'data-old-price', '42');
+        $this->assertSelectorAttributeToNotContain('.price', 'data-old-price', '36');
 
         // Use waitForX methods to wait until some asynchronous process finish
-        $client->waitFor('.popin'); // element is attached to the DOM
-        $client->waitForStaleness('.popin'); // element is removed from the DOM
-        $client->waitForVisibility('.loader'); // element of the DOM becomes visible
-        $client->waitForInvisibility('.loader'); // element of the DOM becomes hidden
-        $client->waitForElementToContain('.total', '25 €'); // text is inserted in the element content
-        $client->waitForElementToNotContain('.promotion', '5%'); // text is removed from the element content
-
+        $client->waitFor('.popin'); // wait for element to be attached to the DOM
+        $client->waitForStaleness('.popin'); // wait for element to be removed from the DOM
+        $client->waitForVisibility('.loader'); // wait for element of the DOM to become visible
+        $client->waitForInvisibility('.loader'); // wait for element of the DOM to become hidden
+        $client->waitForElementToContain('.total', '25 €'); // wait for text to be inserted in the element content
+        $client->waitForElementToNotContain('.promotion', '5%'); // wait for text to be removed from the element content
+        $client->waitForEnabled('[type="submit"]'); // wait for the button to become enabled 
+        $client->waitForDisabled('[type="submit"]'); // wait for  the button to become disabled 
+        $client->waitForAttributeToContain('.price', 'data-old-price', '25 €'); // wait for the attribute to contain content
+        $client->waitForAttributeToNotContain('.price', 'data-old-price', '25 €'); // wait for the attribute to not contain content
+        
+        // Let's predict future
+        $this->assertSelectorWillExist('.popin'); // element will be attached to the DOM
+        $this->assertSelectorWillNotExist('.popin'); // element will be removed from the DOM
+        $this->assertSelectorWillBeVisible('.loader'); // element will be visible
+        $this->assertSelectorWillNotBeVisible('.loader'); // element will be visible
+        $this->assertSelectorWillContain('.total', '25 €'); // text will be inserted in the element content
+        $this->assertSelectorWillNotContain('.promotion', '5%'); // text will be removed from the element content
+        $this->assertSelectorWillBeEnabled('[type="submit"]'); // button will be enabled 
+        $this->assertSelectorWillBeDisabled('[type="submit"]'); // button will be disabled 
+        $this->assertSelectorAttributeWillContain('.price', 'data-old-price', '25 €'); // attribute will contains content
+        $this->assertSelectorAttributeWillNotContain('.price', 'data-old-price', '25 €'); // attribute will not contain content
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ class E2eTest extends PantherTestCase
         $this->assertSelectorWillNotExist('.popin'); // element will be removed from the DOM
         $this->assertSelectorWillBeVisible('.loader'); // element will be visible
         $this->assertSelectorWillNotBeVisible('.loader'); // element will be visible
-        $this->assertSelectorWillContain('.total', '25 €'); // text will be inserted in the element content
+        $this->assertSelectorWillContain('.total', '€25'); // text will be inserted in the element content
         $this->assertSelectorWillNotContain('.promotion', '5%'); // text will be removed from the element content
         $this->assertSelectorWillBeEnabled('[type="submit"]'); // button will be enabled 
         $this->assertSelectorWillBeDisabled('[type="submit"]'); // button will be disabled 

--- a/src/Client.php
+++ b/src/Client.php
@@ -426,6 +426,50 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
         return $this->crawler = $this->createCrawler();
     }
 
+    public function waitForAttributeToContain(string $locator, string $attribute, string $text, int $timeoutInSecond = 30, int $intervalInMillisecond = 250)
+    {
+        $by = self::createWebDriverByFromLocator($locator);
+
+        $this->wait($timeoutInSecond, $intervalInMillisecond)->until(
+            PantherWebDriverExpectedCondition::elementAttributeContains($by, $attribute, $text)
+        );
+
+        return $this->crawler = $this->createCrawler();
+    }
+
+    public function waitForAttributeToNotContain(string $locator, string $attribute, string $text, int $timeoutInSecond = 30, int $intervalInMillisecond = 250)
+    {
+        $by = self::createWebDriverByFromLocator($locator);
+
+        $this->wait($timeoutInSecond, $intervalInMillisecond)->until(
+            PantherWebDriverExpectedCondition::elementAttributeNotContains($by, $attribute, $text)
+        );
+
+        return $this->crawler = $this->createCrawler();
+    }
+
+    public function waitForEnabled(string $locator, int $timeoutInSecond = 30, int $intervalInMillisecond = 250)
+    {
+        $by = self::createWebDriverByFromLocator($locator);
+
+        $this->wait($timeoutInSecond, $intervalInMillisecond)->until(
+            PantherWebDriverExpectedCondition::elementEnabled($by)
+        );
+
+        return $this->crawler = $this->createCrawler();
+    }
+
+    public function waitForDisabled(string $locator, int $timeoutInSecond = 30, int $intervalInMillisecond = 250)
+    {
+        $by = self::createWebDriverByFromLocator($locator);
+
+        $this->wait($timeoutInSecond, $intervalInMillisecond)->until(
+            PantherWebDriverExpectedCondition::elementDisabled($by)
+        );
+
+        return $this->crawler = $this->createCrawler();
+    }
+
     public function getWebDriver(): WebDriver
     {
         $this->start();

--- a/src/WebDriver/PantherWebDriverExpectedCondition.php
+++ b/src/WebDriver/PantherWebDriverExpectedCondition.php
@@ -23,9 +23,61 @@ final class PantherWebDriverExpectedCondition
     {
         return static function (WebDriver $driver) use ($by, $text) {
             try {
-                $element_text = $driver->findElement($by)->getText();
+                $elementText = $driver->findElement($by)->getText();
 
-                return false === strpos($element_text, $text);
+                return false === strpos($elementText, $text);
+            } catch (StaleElementReferenceException $e) {
+                return null;
+            }
+        }
+        ;
+    }
+
+    public static function elementEnabled(WebDriverBy $by)
+    {
+        return static function (WebDriver $driver) use ($by) {
+            try {
+                return $driver->findElement($by)->isEnabled();
+            } catch (StaleElementReferenceException $e) {
+                return null;
+            }
+        }
+        ;
+    }
+
+    public static function elementDisabled(WebDriverBy $by)
+    {
+        return static function (WebDriver $driver) use ($by) {
+            try {
+                return !$driver->findElement($by)->isEnabled();
+            } catch (StaleElementReferenceException $e) {
+                return null;
+            }
+        }
+            ;
+    }
+
+    public static function elementAttributeContains(WebDriverBy $by, string $attribute, string $text)
+    {
+        return static function (WebDriver $driver) use ($by, $attribute, $text) {
+            try {
+                $attributeValue = $driver->findElement($by)->getAttribute($attribute);
+
+                return null !== $attributeValue && false !== strpos($attributeValue, $text);
+            } catch (StaleElementReferenceException $e) {
+                return null;
+            }
+        }
+        ;
+    }
+
+    public static function elementAttributeNotContains(WebDriverBy $by, string $attribute, string $text)
+    {
+        return static function (WebDriver $driver) use ($by, $attribute, $text) {
+            try {
+                $attributeValue = $driver->findElement($by)->getAttribute($attribute);
+
+                return null !== $attributeValue && false === strpos($attributeValue, $text);
             } catch (StaleElementReferenceException $e) {
                 return null;
             }

--- a/src/WebDriver/PantherWebDriverExpectedCondition.php
+++ b/src/WebDriver/PantherWebDriverExpectedCondition.php
@@ -54,7 +54,7 @@ final class PantherWebDriverExpectedCondition
                 return null;
             }
         }
-            ;
+        ;
     }
 
     public static function elementAttributeContains(WebDriverBy $by, string $attribute, string $text)

--- a/src/WebTestAssertionsTrait.php
+++ b/src/WebTestAssertionsTrait.php
@@ -19,7 +19,6 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestAssertionsTrait as BaseWebTestAss
 use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\Panther\Client as PantherClient;
-use Symfony\Component\Panther\DomCrawler\Crawler;
 
 /**
  * Tweaks Symfony's WebTestAssertionsTrait to be compatible with Panther.
@@ -95,24 +94,20 @@ trait WebTestAssertionsTrait
         self::baseAssertPageTitleContains($expectedTitle, $message);
     }
 
-    public static function assertSelectorWillExist(string $locator): Crawler
+    public static function assertSelectorWillExist(string $locator): void
     {
         /** @var PantherClient $client */
         $client = self::getClient();
-        $crawler = $client->waitFor($locator);
+        $client->waitFor($locator);
         self::assertSelectorExists($locator);
-
-        return $crawler;
     }
 
-    public static function assertSelectorWillNotExist(string $locator): Crawler
+    public static function assertSelectorWillNotExist(string $locator): void
     {
         /** @var PantherClient $client */
         $client = self::getClient();
-        $crawler = $client->waitForStaleness($locator);
+        $client->waitForStaleness($locator);
         self::assertSelectorNotExists($locator);
-
-        return $crawler;
     }
 
     public static function assertSelectorIsVisible(string $locator): void
@@ -121,14 +116,12 @@ trait WebTestAssertionsTrait
         self::assertTrue($element->isDisplayed(), 'Failed asserting that element is visible.');
     }
 
-    public static function assertSelectorWillBeVisible(string $locator): Crawler
+    public static function assertSelectorWillBeVisible(string $locator): void
     {
         /** @var PantherClient $client */
         $client = self::getClient();
-        $crawler = $client->waitForVisibility($locator);
+        $client->waitForVisibility($locator);
         self::assertSelectorIsVisible($locator);
-
-        return $crawler;
     }
 
     public static function assertSelectorIsNotVisible(string $locator): void
@@ -137,34 +130,28 @@ trait WebTestAssertionsTrait
         self::assertFalse($element->isDisplayed(), 'Failed asserting that element is not visible.');
     }
 
-    public static function assertSelectorWillNotBeVisible(string $locator): Crawler
+    public static function assertSelectorWillNotBeVisible(string $locator): void
     {
         /** @var PantherClient $client */
         $client = self::getClient();
-        $crawler = $client->waitForInvisibility($locator);
+        $client->waitForInvisibility($locator);
         self::assertSelectorIsNotVisible($locator);
-
-        return $crawler;
     }
 
-    public static function assertSelectorWillContain(string $locator, string $text): Crawler
+    public static function assertSelectorWillContain(string $locator, string $text): void
     {
         /** @var PantherClient $client */
         $client = self::getClient();
-        $crawler = $client->waitForElementToContain($locator, $text);
+        $client->waitForElementToContain($locator, $text);
         self::assertSelectorTextContains($locator, $text);
-
-        return $crawler;
     }
 
-    public static function assertSelectorWillNotContain(string $locator, string $text): Crawler
+    public static function assertSelectorWillNotContain(string $locator, string $text): void
     {
         /** @var PantherClient $client */
         $client = self::getClient();
-        $crawler = $client->waitForElementToNotContain($locator, $text);
+        $client->waitForElementToNotContain($locator, $text);
         self::assertSelectorTextNotContains($locator, $text);
-
-        return $crawler;
     }
 
     public static function assertSelectorIsEnabled(string $locator): void
@@ -173,14 +160,12 @@ trait WebTestAssertionsTrait
         self::assertTrue($element->isEnabled(), 'Failed asserting that element is enabled.');
     }
 
-    public static function assertSelectorWillBeEnabled(string $locator): Crawler
+    public static function assertSelectorWillBeEnabled(string $locator): void
     {
         /** @var PantherClient $client */
         $client = self::getClient();
-        $crawler = $client->waitForEnabled($locator);
-        self::assertSelectorAttributeToContain($locator, 'disabled');
-
-        return $crawler;
+        $client->waitForEnabled($locator);
+        self::assertSelectorAttributeContains($locator, 'disabled');
     }
 
     public static function assertSelectorIsDisabled(string $locator): void
@@ -189,17 +174,15 @@ trait WebTestAssertionsTrait
         self::assertFalse($element->isEnabled(), 'Failed asserting that element is disabled.');
     }
 
-    public static function assertSelectorWillBeDisabled(string $locator): Crawler
+    public static function assertSelectorWillBeDisabled(string $locator): void
     {
         /** @var PantherClient $client */
         $client = self::getClient();
-        $crawler = $client->waitForDisabled($locator);
-        self::assertSelectorAttributeToContain($locator, 'disabled', 'true');
-
-        return $crawler;
+        $client->waitForDisabled($locator);
+        self::assertSelectorAttributeContains($locator, 'disabled', 'true');
     }
 
-    public static function assertSelectorAttributeToContain(string $locator, string $attribute, string $text = null): void
+    public static function assertSelectorAttributeContains(string $locator, string $attribute, string $text = null): void
     {
         $element = self::findElement($locator);
 
@@ -212,35 +195,30 @@ trait WebTestAssertionsTrait
         self::assertStringContainsString($text, $element->getAttribute($attribute));
     }
 
-    public static function assertSelectorAttributeWillContain(string $locator, string $attribute, string $text): Crawler
+    public static function assertSelectorAttributeWillContain(string $locator, string $attribute, string $text): void
     {
         /** @var PantherClient $client */
         $client = self::getClient();
-        $crawler = $client->waitForAttributeToContain($locator, $attribute, $text);
-        self::assertSelectorAttributeToContain($locator, $attribute, $text);
-
-        return $crawler;
+        $client->waitForAttributeToContain($locator, $attribute, $text);
+        self::assertSelectorAttributeContains($locator, $attribute, $text);
     }
 
-    public static function assertSelectorAttributeToNotContain(string $locator, string $attribute, string $text): void
+    public static function assertSelectorAttributeNotContains(string $locator, string $attribute, string $text): void
     {
         $element = self::findElement($locator);
         self::assertStringNotContainsString($text, $element->getAttribute($attribute));
     }
 
-    public static function assertSelectorAttributeWillNotContain(string $locator, string $attribute, string $text): Crawler
+    public static function assertSelectorAttributeWillNotContain(string $locator, string $attribute, string $text): void
     {
         /** @var PantherClient $client */
         $client = self::getClient();
-        $crawler = $client->waitForAttributeToNotContain($locator, $attribute, $text);
-        self::assertSelectorAttributeToNotContain($locator, $attribute, $text);
-
-        return $crawler;
+        $client->waitForAttributeToNotContain($locator, $attribute, $text);
+        self::assertSelectorAttributeNotContains($locator, $attribute, $text);
     }
 
     private static function findElement(string $locator): WebDriverElement
     {
-        /** @var PantherClient $client */
         /** @var PantherClient $client */
         $client = self::getClient();
         $by = $client::createWebDriverByFromLocator($locator);

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -43,8 +43,8 @@ class AssertionsTest extends TestCase
         $this->assertInputValueSame('in', 'test');
         $this->assertSelectorIsVisible('.p-1');
         $this->assertSelectorIsEnabled('[name="in"]');
-        $this->assertSelectorAttributeToContain('.price', 'data-old-price', '42');
-        $this->assertSelectorAttributeToNotContain('.price', 'data-old-price', '36');
+        $this->assertSelectorAttributeContains('.price', 'data-old-price', '42');
+        $this->assertSelectorAttributeNotContains('.price', 'data-old-price', '36');
         self::createPantherClient()->request('GET', '/input-disabled.html');
         $this->assertSelectorIsDisabled('[name="in-disabled"]');
         self::createPantherClient()->request('GET', '/text-hidden.html');

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -43,6 +43,8 @@ class AssertionsTest extends TestCase
         $this->assertInputValueSame('in', 'test');
         $this->assertSelectorIsVisible('.p-1');
         $this->assertSelectorIsEnabled('[name="in"]');
+        $this->assertSelectorAttributeToContain('.price', 'data-old-price', '42');
+        $this->assertSelectorAttributeToNotContain('.price', 'data-old-price', '36');
         self::createPantherClient()->request('GET', '/input-disabled.html');
         $this->assertSelectorIsDisabled('[name="in-disabled"]');
         self::createPantherClient()->request('GET', '/text-hidden.html');

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -128,6 +128,54 @@ class ClientTest extends TestCase
     /**
      * @dataProvider waitForDataProvider
      */
+    public function testWaitForEnabled(string $locator)
+    {
+        $client = self::createPantherClient();
+        $client->request('GET', '/waitfor-input-to-be-enabled.html');
+        $crawler = $client->waitForEnabled($locator);
+        $this->assertInstanceOf(Crawler::class, $crawler);
+        $this->assertTrue($crawler->filter('#hello')->isEnabled());
+    }
+
+    /**
+     * @dataProvider waitForDataProvider
+     */
+    public function testWaitForDisabled(string $locator)
+    {
+        $client = self::createPantherClient();
+        $client->request('GET', '/waitfor-input-to-be-disabled.html');
+        $crawler = $client->waitForDisabled($locator);
+        $this->assertInstanceOf(Crawler::class, $crawler);
+        $this->assertFalse($crawler->filter('#hello')->isEnabled());
+    }
+
+    /**
+     * @dataProvider waitForDataProvider
+     */
+    public function testWaitForAttributeToContain(string $locator)
+    {
+        $client = self::createPantherClient();
+        $crawler = $client->request('GET', '/waitfor-attribute-to-contain.html');
+        $c = $client->waitForAttributeToContain($locator, 'data-old-price', '42');
+        $this->assertInstanceOf(Crawler::class, $c);
+        $this->assertSame('42', $crawler->filter('#hello')->getAttribute('data-old-price'));
+    }
+
+    /**
+     * @dataProvider waitForDataProvider
+     */
+    public function testWaitForAttributeToNotContain(string $locator)
+    {
+        $client = self::createPantherClient();
+        $client->request('GET', '/waitfor-attribute-to-contain.html');
+        $crawler = $client->waitForAttributeToContain($locator, 'data-old-price', '36');
+        $this->assertInstanceOf(Crawler::class, $crawler);
+        $this->assertSame('36', $crawler->filter('#hello')->getAttribute('data-old-price'));
+    }
+
+    /**
+     * @dataProvider waitForDataProvider
+     */
     public function testWaitForStalenessElement(string $locator): void
     {
         $client = self::createPantherClient();

--- a/tests/DomCrawler/CrawlerTest.php
+++ b/tests/DomCrawler/CrawlerTest.php
@@ -76,6 +76,9 @@ class CrawlerTest extends TestCase
                 case 1:
                     $this->assertSame('P2', $crawler->text());
                     break;
+                case 2:
+                    $this->assertSame('36', $crawler->text());
+                    break;
                 default:
                     $this->fail(\sprintf('Unexpected index "%d".', $i));
             }
@@ -195,7 +198,7 @@ class CrawlerTest extends TestCase
             $names[$i] = $c->nodeName();
         });
 
-        $this->assertSame(['h1', 'main', 'p', 'p', 'input'], $names);
+        $this->assertSame(['h1', 'main', 'p', 'p', 'input', 'p'], $names);
     }
 
     /**
@@ -212,7 +215,7 @@ class CrawlerTest extends TestCase
             $names[$i] = $c->nodeName();
         });
 
-        $this->assertSame(['p', 'p'], $names);
+        $this->assertSame(['p', 'p', 'p'], $names);
     }
 
     /**

--- a/tests/FutureAssertionsTest.php
+++ b/tests/FutureAssertionsTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the Panther project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Panther\Tests;
+
+use Symfony\Component\Panther\DomCrawler\Crawler;
+
+class FutureAssertionsTest extends TestCase
+{
+    /** @dataProvider futureDataProvider */
+    public function testFutureExistenceAssertion(string $locator): void
+    {
+        self::createPantherClient()->request('GET', '/waitfor.html');
+        $crawler = $this->assertSelectorWillExist($locator);
+        $this->assertInstanceOf(Crawler::class, $crawler);
+        $this->assertSame('Hello', $crawler->filter('#hello')->text());
+    }
+
+    /** @dataProvider futureDataProvider */
+    public function testFutureStalenessAssertion(string $locator): void
+    {
+        self::createPantherClient()->request('GET', '/waitfor-staleness.html');
+        $crawler = $this->assertSelectorWillNotExist($locator);
+        $this->assertInstanceOf(Crawler::class, $crawler);
+    }
+
+    /** @dataProvider futureDataProvider */
+    public function testFutureVisibilityAssertion(string $locator): void
+    {
+        self::createPantherClient()->request('GET', '/waitfor-element-to-be-visible.html');
+        $crawler = $this->assertSelectorWillBeVisible($locator);
+        $this->assertInstanceOf(Crawler::class, $crawler);
+        $this->assertSame('Hello', $crawler->filter('#hello')->text());
+        $this->assertSelectorExists($locator);
+    }
+
+    /** @dataProvider futureDataProvider */
+    public function testFutureInvisibilityAssertion(string $locator): void
+    {
+        self::createPantherClient()->request('GET', '/waitfor-element-to-be-invisible.html');
+        $crawler = $this->assertSelectorWillNotBeVisible($locator);
+        $this->assertSame('', $crawler->filter('#hello')->text());
+    }
+
+    /** @dataProvider futureDataProvider */
+    public function testFutureContainAssertion(string $locator): void
+    {
+        self::createPantherClient()->request('GET', '/waitfor-element-to-contain.html');
+        $crawler = $this->assertSelectorWillContain($locator, 'new content');
+        $this->assertSame('Hello new content', $crawler->filter('#hello')->text());
+    }
+
+    /** @dataProvider futureDataProvider */
+    public function testFutureNotContainAssertion(string $locator): void
+    {
+        self::createPantherClient()->request('GET', '/waitfor-element-to-not-contain.html');
+        $crawler = $this->assertSelectorWillNotContain($locator, 'removed content');
+        $this->assertSame('Hello', $crawler->filter('#hello')->text());
+    }
+
+    /** @dataProvider futureDataProvider */
+    public function testFutureEnabledAssertion(string $locator): void
+    {
+        self::createPantherClient()->request('GET', '/waitfor-input-to-be-enabled.html');
+        $crawler = $this->assertSelectorWillBeEnabled($locator);
+        $this->assertNull($crawler->filter('#hello')->getAttribute('disabled'));
+    }
+
+    /** @dataProvider futureDataProvider */
+    public function testFutureDisabledAssertion(string $locator): void
+    {
+        self::createPantherClient()->request('GET', '/waitfor-input-to-be-disabled.html');
+        $crawler = $this->assertSelectorWillBeDisabled($locator);
+        $this->assertSame('true', $crawler->filter('#hello')->getAttribute('disabled'));
+    }
+
+    /**
+     * @dataProvider futureDataProvider
+     */
+    public function testFutureAttributeContainAssertion(string $locator)
+    {
+        self::createPantherClient()->request('GET', '/waitfor-attribute-to-contain.html');
+        $crawler = $this->assertSelectorAttributeWillContain($locator, 'data-old-price', '42');
+        $this->assertSame('42', $crawler->filter('#hello')->getAttribute('data-old-price'));
+    }
+
+    /**
+     * @dataProvider futureDataProvider
+     */
+    public function testFutureAttributeNotContainAssertion(string $locator)
+    {
+        self::createPantherClient()->request('GET', '/waitfor-attribute-to-contain.html');
+        $crawler = $this->assertSelectorAttributeWillNotContain($locator, 'data-old-price', '36');
+        $this->assertSame('42', $crawler->filter('#hello')->getAttribute('data-old-price'));
+    }
+
+    public function futureDataProvider(): iterable
+    {
+        yield 'css selector' => ['locator' => '#hello'];
+        yield 'xpath expression' => ['locator' => '//*[@id="hello"]'];
+    }
+}

--- a/tests/FutureAssertionsTest.php
+++ b/tests/FutureAssertionsTest.php
@@ -13,33 +13,29 @@ declare(strict_types=1);
 
 namespace Symfony\Component\Panther\Tests;
 
-use Symfony\Component\Panther\DomCrawler\Crawler;
-
 class FutureAssertionsTest extends TestCase
 {
     /** @dataProvider futureDataProvider */
     public function testFutureExistenceAssertion(string $locator): void
     {
-        self::createPantherClient()->request('GET', '/waitfor.html');
-        $crawler = $this->assertSelectorWillExist($locator);
-        $this->assertInstanceOf(Crawler::class, $crawler);
+        $crawler = self::createPantherClient()->request('GET', '/waitfor.html');
+        $this->assertSelectorWillExist($locator);
         $this->assertSame('Hello', $crawler->filter('#hello')->text());
     }
 
     /** @dataProvider futureDataProvider */
     public function testFutureStalenessAssertion(string $locator): void
     {
-        self::createPantherClient()->request('GET', '/waitfor-staleness.html');
-        $crawler = $this->assertSelectorWillNotExist($locator);
-        $this->assertInstanceOf(Crawler::class, $crawler);
+        $crawler = self::createPantherClient()->request('GET', '/waitfor-staleness.html');
+        $this->assertSelectorWillNotExist($locator);
+        $this->assertSame(0, \count($crawler->filter('body')->children()));
     }
 
     /** @dataProvider futureDataProvider */
     public function testFutureVisibilityAssertion(string $locator): void
     {
-        self::createPantherClient()->request('GET', '/waitfor-element-to-be-visible.html');
-        $crawler = $this->assertSelectorWillBeVisible($locator);
-        $this->assertInstanceOf(Crawler::class, $crawler);
+        $crawler = self::createPantherClient()->request('GET', '/waitfor-element-to-be-visible.html');
+        $this->assertSelectorWillBeVisible($locator);
         $this->assertSame('Hello', $crawler->filter('#hello')->text());
         $this->assertSelectorExists($locator);
     }
@@ -47,40 +43,40 @@ class FutureAssertionsTest extends TestCase
     /** @dataProvider futureDataProvider */
     public function testFutureInvisibilityAssertion(string $locator): void
     {
-        self::createPantherClient()->request('GET', '/waitfor-element-to-be-invisible.html');
-        $crawler = $this->assertSelectorWillNotBeVisible($locator);
+        $crawler = self::createPantherClient()->request('GET', '/waitfor-element-to-be-invisible.html');
+        $this->assertSelectorWillNotBeVisible($locator);
         $this->assertSame('', $crawler->filter('#hello')->text());
     }
 
     /** @dataProvider futureDataProvider */
     public function testFutureContainAssertion(string $locator): void
     {
-        self::createPantherClient()->request('GET', '/waitfor-element-to-contain.html');
-        $crawler = $this->assertSelectorWillContain($locator, 'new content');
+        $crawler = self::createPantherClient()->request('GET', '/waitfor-element-to-contain.html');
+        $this->assertSelectorWillContain($locator, 'new content');
         $this->assertSame('Hello new content', $crawler->filter('#hello')->text());
     }
 
     /** @dataProvider futureDataProvider */
     public function testFutureNotContainAssertion(string $locator): void
     {
-        self::createPantherClient()->request('GET', '/waitfor-element-to-not-contain.html');
-        $crawler = $this->assertSelectorWillNotContain($locator, 'removed content');
+        $crawler = self::createPantherClient()->request('GET', '/waitfor-element-to-not-contain.html');
+        $this->assertSelectorWillNotContain($locator, 'removed content');
         $this->assertSame('Hello', $crawler->filter('#hello')->text());
     }
 
     /** @dataProvider futureDataProvider */
     public function testFutureEnabledAssertion(string $locator): void
     {
-        self::createPantherClient()->request('GET', '/waitfor-input-to-be-enabled.html');
-        $crawler = $this->assertSelectorWillBeEnabled($locator);
+        $crawler = self::createPantherClient()->request('GET', '/waitfor-input-to-be-enabled.html');
+        $this->assertSelectorWillBeEnabled($locator);
         $this->assertNull($crawler->filter('#hello')->getAttribute('disabled'));
     }
 
     /** @dataProvider futureDataProvider */
     public function testFutureDisabledAssertion(string $locator): void
     {
-        self::createPantherClient()->request('GET', '/waitfor-input-to-be-disabled.html');
-        $crawler = $this->assertSelectorWillBeDisabled($locator);
+        $crawler = self::createPantherClient()->request('GET', '/waitfor-input-to-be-disabled.html');
+        $this->assertSelectorWillBeDisabled($locator);
         $this->assertSame('true', $crawler->filter('#hello')->getAttribute('disabled'));
     }
 
@@ -89,8 +85,8 @@ class FutureAssertionsTest extends TestCase
      */
     public function testFutureAttributeContainAssertion(string $locator)
     {
-        self::createPantherClient()->request('GET', '/waitfor-attribute-to-contain.html');
-        $crawler = $this->assertSelectorAttributeWillContain($locator, 'data-old-price', '42');
+        $crawler = self::createPantherClient()->request('GET', '/waitfor-attribute-to-contain.html');
+        $this->assertSelectorAttributeWillContain($locator, 'data-old-price', '42');
         $this->assertSame('42', $crawler->filter('#hello')->getAttribute('data-old-price'));
     }
 
@@ -99,8 +95,8 @@ class FutureAssertionsTest extends TestCase
      */
     public function testFutureAttributeNotContainAssertion(string $locator)
     {
-        self::createPantherClient()->request('GET', '/waitfor-attribute-to-contain.html');
-        $crawler = $this->assertSelectorAttributeWillNotContain($locator, 'data-old-price', '36');
+        $crawler = self::createPantherClient()->request('GET', '/waitfor-attribute-to-contain.html');
+        $this->assertSelectorAttributeWillNotContain($locator, 'data-old-price', '36');
         $this->assertSame('42', $crawler->filter('#hello')->getAttribute('data-old-price'));
     }
 

--- a/tests/fixtures/basic.html
+++ b/tests/fixtures/basic.html
@@ -15,5 +15,6 @@
     <p class="p-1">P1</p>
     <p class="p-2">P2</p>
     <input name="in" value="test">
+    <p class="price" data-old-price="42">36</p>
 </body>
 </html>

--- a/tests/fixtures/waitfor-attribute-to-contain.html
+++ b/tests/fixtures/waitfor-attribute-to-contain.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>WaitFor - Element to contain</title>
+</head>
+<body>
+    <p id="hello" data-old-price="36">36</p>
+<script>
+  window.setTimeout(function () {
+    document.getElementById('hello').dataset.oldPrice = 42;
+  }, 1000);
+</script>
+</body>
+</html>

--- a/tests/fixtures/waitfor-input-to-be-disabled.html
+++ b/tests/fixtures/waitfor-input-to-be-disabled.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>WaitFor - Present element in DOM to be visible</title>
+</head>
+<body>
+    <input id="hello" />
+    <script>
+      window.setTimeout(function () {
+        document.getElementById('hello').disabled = true;
+      }, 1000);
+    </script>
+</body>
+</html>

--- a/tests/fixtures/waitfor-input-to-be-enabled.html
+++ b/tests/fixtures/waitfor-input-to-be-enabled.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>WaitFor - Present element in DOM to be visible</title>
+</head>
+<body>
+    <input id="hello" disabled />
+    <script>
+      window.setTimeout(function () {
+        document.getElementById('hello').disabled = false;
+      }, 1000);
+    </script>
+</body>
+</html>

--- a/tests/fixtures/waitfor-staleness.html
+++ b/tests/fixtures/waitfor-staleness.html
@@ -3,14 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <title>WaitFor - Staleness of an element</title>
+    <script>
+      window.setTimeout(function () {
+        document.getElementById('hello').remove();
+      }, 1000);
+    </script>
 </head>
 <body>
     <p id="hello">Hello</p>
-
-<script>
-  window.setTimeout(function () {
-    document.getElementById('hello').remove();
-  }, 1000);
-</script>
 </body>
 </html>


### PR DESCRIPTION
Sometime it's pretty frustrating to assert something that will happened in the future. For example, is you want to test that a popin will be opened, you have to make:

```php
$client->waitFor('.popin');
$this->assertSelectorExists('.popin');  // test have to contain an assertion so this one is mandatory
```

This PR allow to make some prediction like this one:

```php
$this->assertSelectorWillExist('.popin');
```


It introduces:

**new assertions in the present:**
- assertSelectorAttributeContains
- assertSelectorAttributeNotContains


**new wait methods:**
- waitForEnabled
- waitForDisabled
- waitForAttributeToContain
- waitForAttributeToNotContain


**new assertions in the future:**
- assertSelectorWillExist
- assertSelectorWillNotExist
- assertSelectorWillBeVisible
- assertSelectorWillNotBeVisible
- assertSelectorWillContain
- assertSelectorWillNotContain
- assertSelectorWillBeEnabled
- assertSelectorWillBeDisabled
- assertSelectorAttributeWillContain
- assertSelectorAttributeWillNotContain