### PR TITLE
Add documentation about multi-domain & separate processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ class E2eTest extends PantherTestCase
 }
 ```
 
-### Having a multi-domain application
+### Having a Multi-domain Application
 
 It happens that your PHP/Symfony application might serve several different domain names.
 
@@ -439,6 +439,7 @@ class FirstDomainTest extends PantherTestCase
     }
 }
 ```
+
 ```php
 <?php
 

--- a/README.md
+++ b/README.md
@@ -431,7 +431,9 @@ class FirstDomainTest extends PantherTestCase
      */
     public function testMyApp(): void
     {
-        $pantherClient = static::createPantherClient(['external_base_uri' => 'http://mydomain.localhost:8000']);
+        $pantherClient = static::createPantherClient([
+            'external_base_uri' => 'http://mydomain.localhost:8000',
+        ]);
         
         // Your tests
     }
@@ -451,7 +453,9 @@ class SecondDomainTest extends PantherTestCase
      */
     public function testMyApp(): void
     {
-        $pantherClient = static::createPantherClient(['external_base_uri' => 'http://anotherdomain.localhost:8000']);
+        $pantherClient = static::createPantherClient([
+            'external_base_uri' => 'http://anotherdomain.localhost:8000',
+        ]);
         
         // Your tests
     }

--- a/README.md
+++ b/README.md
@@ -402,6 +402,62 @@ class E2eTest extends PantherTestCase
 }
 ```
 
+### Having a multi-domain application
+
+It happens that your PHP/Symfony application might serve several different domain names.
+
+As Panther saves the Client in memory between tests to improve performances, you will have to run your tests in separate
+processes if you write several tests using Panther for different domain names.
+
+To do so, you can use the native `@runInSeparateProcess` PHPUnit annotation.
+
+**ℹ Note:** it is really convenient to use the `external_base_uri` option and start your own webserver in the background,
+because Panther will not have to start and stop your server on each test. [Symfony CLI](https://symfony.com/download) can
+be a quick and easy way to do so. 
+
+Here is an example using the `external_base_uri` option to determine the domain name used by the Client:
+
+```php
+<?php
+
+namespace App\Tests;
+
+use Symfony\Component\Panther\PantherTestCase;
+
+class FirstDomainTest extends PantherTestCase
+{
+    /**
+     * @runInSeparateProcess
+     */
+    public function testMyApp(): void
+    {
+        $pantherClient = static::createPantherClient(['external_base_uri' => 'http://mydomain.localhost:8000']);
+        
+        // Your tests
+    }
+}
+```
+```php
+<?php
+
+namespace App\Tests;
+
+use Symfony\Component\Panther\PantherTestCase;
+
+class SecondDomainTest extends PantherTestCase
+{
+    /**
+     * @runInSeparateProcess
+     */
+    public function testMyApp(): void
+    {
+        $pantherClient = static::createPantherClient(['external_base_uri' => 'http://anotherdomain.localhost:8000']);
+        
+        // Your tests
+    }
+}
+```
+
 ### Using a Proxy
 
 To use a proxy server, set the following environment variable: `PANTHER_CHROME_ARGUMENTS='--proxy-server=socks://127.0.0.1:9050'`


### PR DESCRIPTION
The origin of this use-case is [this tweet](https://twitter.com/Pierstoval/status/1359240914410078210).

As Panther reuses clients between tests, it's impossible to run 2 different tests with different `external_base_uri` values, because the first test that'll be executed will set the value for all other test cases.

So to avoid this, I used the `@runInSeparateProcess` annotation to make sure a new client is recreated on every test.

This doesn't seem to have an impact on performances, especially because E2E tests with Panther are really slow, so the impact is negligible I guess. This could be benchmarked on apps that contain a lot of E2E tests (mine only has 2 tests, since tests are heavily hard to write on this legacy app 🤣).

For now, I prefer this to be documented here, because having to support such really specific use-case would cause quite a maintenance burden for a really few amount of apps, and for now, the "workaround" is pretty much everything needed to fulfill the use-case _in fine_. If some day another workaround can be found in Panther for almost no-cost, it could be a better alternative. But I'm not really into adding more configuration/env vars/etc. while PHPUnit already provides what's necessary.

WDYT?