### PR TITLE
fix: prevent destructing the client if a crawler is still active

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -283,7 +283,7 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
         $this->start();
         $elements = $this->webDriver->findElements(WebDriverBy::cssSelector('html'));
 
-        return new PantherCrawler($elements, $this->webDriver, $this->webDriver->getCurrentURL());
+        return new PantherCrawler($elements, $this, $this->webDriver->getCurrentURL());
     }
 
     protected function doRequest($request)

--- a/tests/DomCrawler/CrawlerTest.php
+++ b/tests/DomCrawler/CrawlerTest.php
@@ -338,4 +338,15 @@ class CrawlerTest extends TestCase
 
         self::createPantherClient()->request('GET', self::$baseUri.'/normalize.html')->filter('#normalize')->text(null, false);
     }
+
+    public function testCrawlerStillWorksAfterClientDestruction(): void
+    {
+        $client = Client::createChromeClient();
+        self::startWebServer();
+
+        $crawler = $client->request('GET', self::$baseUri.'/basic.html');
+        unset($client);
+
+        $this->assertStringContainsString('<title>A basic page</title>', $crawler->html());
+    }
 }


### PR DESCRIPTION
Attempt to fix #418. Doesn't work properly yet because the `Process` instance handling ChromeDriver can be destructed before the `Client` instance, triggering an error.