### PR TITLE
createPantherClient improvement

### DIFF
--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -149,11 +149,11 @@ trait PantherTestCaseTrait
      */
     protected static function createPantherClient(array $options = [], array $kernelOptions = [], array $managerOptions = []/*, array $browserArguments = []*/): PantherClient
     {
-        if (\func_num_args() < 4 && __CLASS__ !== (new \ReflectionClass(static::class))->getName() && __CLASS__ !== (new \ReflectionMethod(static::class,__FUNCTION__))->getDeclaringClass()->getName()) {
+        if (\func_num_args() < 4 && __CLASS__ !== (new \ReflectionClass(static::class))->getName() && __CLASS__ !== (new \ReflectionMethod(static::class, __FUNCTION__))->getDeclaringClass()->getName()) {
             @trigger_error(sprintf('The "%s()" method will have a new "array $browserArguments = []" argument in version 1.1.0, not defining it is deprecated since Symfony 1.0.1.', __METHOD__), E_USER_DEPRECATED);
         }
 
-        $browserArguments = 3 < \func_num_args() ? func_get_arg(3) : [];
+        $browserArguments = 3 < \func_num_args() ? \func_get_arg(3) : [];
 
         $browser = ($options['browser'] ?? self::$defaultOptions['browser'] ?? static::CHROME);
         $callGetClient = \is_callable([self::class, 'getClient']) && (new \ReflectionMethod(self::class, 'getClient'))->isStatic();
@@ -169,8 +169,8 @@ trait PantherTestCaseTrait
 
         // Only allow browser arguments if a browser has been explicitly specified
         if (\is_array($browserArguments) && !\array_key_exists('browser', $options)) {
-            @trigger_error('Specifying $browserArguments implies that you specifically set the browser in $options. $browserArguments will be ignored.', E_USER_WARNING);
-            $browserArguments = null;
+            @trigger_error('Specifying $browserArguments requires that you specifically set the browser in $options. $browserArguments will be ignored.', E_USER_WARNING);
+            $browserArguments = [];
         }
 
         self::startWebServer($options);

--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -161,6 +161,7 @@ trait PantherTestCaseTrait
      * Creates the primary browser.
      *
      * @param array $options see {@see $defaultOptions}
+     *
      * @throws \InvalidArgumentException
      */
     protected static function createPantherClient(array $options = [], array $kernelOptions = [], array $managerOptions = []): PantherClient
@@ -186,9 +187,9 @@ trait PantherTestCaseTrait
         if (\array_key_exists('browser_arguments', $options)) {
             if (!\is_array($options['browser_arguments'])) {
                 throw new \InvalidArgumentException('Expected key "browser_arguments" to be an array.');
-            } else {
-                $browserArguments = $options['browser_arguments'];
             }
+
+            $browserArguments = $options['browser_arguments'];
         }
 
         if (PantherTestCase::CHROME === $browser) {

--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -149,8 +149,8 @@ trait PantherTestCaseTrait
      */
     protected static function createPantherClient(array $options = [], array $kernelOptions = [], array $managerOptions = []/*, array $browserArguments = []*/): PantherClient
     {
-        if (\func_num_args() < 4 && \__CLASS__ !== (new \ReflectionClass(static::class))->getName() && \__CLASS__ !== (new \ReflectionMethod(static::class, \__FUNCTION__))->getDeclaringClass()->getName()) {
-            @trigger_error(sprintf('The "%s()" method will have a new "array $browserArguments = []" argument in version 1.1.0, not defining it is deprecated since Symfony 1.0.1.', \__METHOD__), \E_USER_DEPRECATED);
+        if (\func_num_args() < 4 && __CLASS__ !== (new \ReflectionClass(static::class))->getName() && __CLASS__ !== (new \ReflectionMethod(static::class, __FUNCTION__))->getDeclaringClass()->getName()) {
+            @trigger_error(sprintf('The "%s()" method will have a new "array $browserArguments = []" argument in version 1.1.0, not defining it is deprecated since Symfony 1.0.1.', __METHOD__), \E_USER_DEPRECATED);
         }
 
         $browserArguments = 3 < \func_num_args() ? \func_get_arg(3) : [];

--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -147,7 +147,7 @@ trait PantherTestCaseTrait
      *
      * @param array $options see {@see $defaultOptions}
      */
-    protected static function createPantherClient(array $options = [], array $kernelOptions = [], array $managerOptions = []): PantherClient
+    protected static function createPantherClient(array $options = [], array $kernelOptions = [], array $managerOptions = [], array $browserArguments = null): PantherClient
     {
         $browser = ($options['browser'] ?? self::$defaultOptions['browser'] ?? static::CHROME);
         $callGetClient = \is_callable([self::class, 'getClient']) && (new \ReflectionMethod(self::class, 'getClient'))->isStatic();
@@ -161,12 +161,17 @@ trait PantherTestCaseTrait
             }
         }
 
+        // Only allow browser arguments if a browser has been explicitly specified
+        if (is_array($browserArguments) && !array_key_exists('browser', $options)) {
+            $browserArguments = null;
+        }
+
         self::startWebServer($options);
 
         if (static::CHROME === $browser) {
-            self::$pantherClients[0] = self::$pantherClient = Client::createChromeClient(null, null, $managerOptions, self::$baseUri);
+            self::$pantherClients[0] = self::$pantherClient = Client::createChromeClient(null, $browserArguments, $managerOptions, self::$baseUri);
         } else {
-            self::$pantherClients[0] = self::$pantherClient = Client::createFirefoxClient(null, null, $managerOptions, self::$baseUri);
+            self::$pantherClients[0] = self::$pantherClient = Client::createFirefoxClient(null, $browserArguments, $managerOptions, self::$baseUri);
         }
 
         if (\is_a(self::class, KernelTestCase::class, true)) {

--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -163,7 +163,15 @@ trait PantherTestCaseTrait
 
         self::startWebServer($options);
 
-        $browserArguments = \array_key_exists('browser_arguments', $options) && \is_array($options['browser_arguments']) ? $options['browser_arguments'] : [];
+        $browserArguments = null;
+
+        if (\array_key_exists('browser_arguments', $options)) {
+            if (!\is_array($options['browser_arguments'])) {
+                @trigger_error('Expected key "browser_arguments" to be an array.', \E_USER_WARNING);
+            } else {
+                $browserArguments = $options['browser_arguments'];
+            }
+        }
 
         if (static::CHROME === $browser) {
             self::$pantherClients[0] = self::$pantherClient = Client::createChromeClient(null, $browserArguments, $managerOptions, self::$baseUri);

--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -162,7 +162,7 @@ trait PantherTestCaseTrait
         }
 
         // Only allow browser arguments if a browser has been explicitly specified
-        if (is_array($browserArguments) && !array_key_exists('browser', $options)) {
+        if (\is_array($browserArguments) && !\array_key_exists('browser', $options)) {
             $browserArguments = null;
         }
 

--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -168,6 +168,7 @@ trait PantherTestCaseTrait
     {
         $browser = ($options['browser'] ?? self::$defaultOptions['browser'] ?? PantherTestCase::CHROME);
         $callGetClient = \is_callable([self::class, 'getClient']) && (new \ReflectionMethod(self::class, 'getClient'))->isStatic();
+
         if (null !== self::$pantherClient) {
             $browserManager = self::$pantherClient->getBrowserManager();
             if (

--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -147,8 +147,14 @@ trait PantherTestCaseTrait
      *
      * @param array $options see {@see $defaultOptions}
      */
-    protected static function createPantherClient(array $options = [], array $kernelOptions = [], array $managerOptions = [], array $browserArguments = null): PantherClient
+    protected static function createPantherClient(array $options = [], array $kernelOptions = [], array $managerOptions = []/*, array $browserArguments = []*/): PantherClient
     {
+        if (\func_num_args() < 4 && __CLASS__ !== (new \ReflectionClass(static::class))->getName() && __CLASS__ !== (new \ReflectionMethod(static::class,__FUNCTION__))->getDeclaringClass()->getName()) {
+            @trigger_error(sprintf('The "%s()" method will have a new "array $browserArguments = []" argument in version 1.1.0, not defining it is deprecated since Symfony 1.0.1.', __METHOD__), E_USER_DEPRECATED);
+        }
+
+        $browserArguments = 3 < \func_num_args() ? func_get_arg(3) : [];
+
         $browser = ($options['browser'] ?? self::$defaultOptions['browser'] ?? static::CHROME);
         $callGetClient = \is_callable([self::class, 'getClient']) && (new \ReflectionMethod(self::class, 'getClient'))->isStatic();
         if (null !== self::$pantherClient) {
@@ -163,6 +169,7 @@ trait PantherTestCaseTrait
 
         // Only allow browser arguments if a browser has been explicitly specified
         if (\is_array($browserArguments) && !\array_key_exists('browser', $options)) {
+            @trigger_error('Specifying $browserArguments implies that you specifically set the browser in $options. $browserArguments will be ignored.', E_USER_WARNING);
             $browserArguments = null;
         }
 

--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -149,8 +149,8 @@ trait PantherTestCaseTrait
      */
     protected static function createPantherClient(array $options = [], array $kernelOptions = [], array $managerOptions = []/*, array $browserArguments = []*/): PantherClient
     {
-        if (\func_num_args() < 4 && __CLASS__ !== (new \ReflectionClass(static::class))->getName() && __CLASS__ !== (new \ReflectionMethod(static::class, __FUNCTION__))->getDeclaringClass()->getName()) {
-            @trigger_error(sprintf('The "%s()" method will have a new "array $browserArguments = []" argument in version 1.1.0, not defining it is deprecated since Symfony 1.0.1.', __METHOD__), E_USER_DEPRECATED);
+        if (\func_num_args() < 4 && \__CLASS__ !== (new \ReflectionClass(static::class))->getName() && \__CLASS__ !== (new \ReflectionMethod(static::class, \__FUNCTION__))->getDeclaringClass()->getName()) {
+            @trigger_error(sprintf('The "%s()" method will have a new "array $browserArguments = []" argument in version 1.1.0, not defining it is deprecated since Symfony 1.0.1.', \__METHOD__), \E_USER_DEPRECATED);
         }
 
         $browserArguments = 3 < \func_num_args() ? \func_get_arg(3) : [];
@@ -169,7 +169,7 @@ trait PantherTestCaseTrait
 
         // Only allow browser arguments if a browser has been explicitly specified
         if (\is_array($browserArguments) && !\array_key_exists('browser', $options)) {
-            @trigger_error('Specifying $browserArguments requires that you specifically set the browser in $options. $browserArguments will be ignored.', E_USER_WARNING);
+            @trigger_error('Specifying $browserArguments requires that you specifically set the browser in $options. $browserArguments will be ignored.', \E_USER_WARNING);
             $browserArguments = [];
         }
 

--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -147,14 +147,8 @@ trait PantherTestCaseTrait
      *
      * @param array $options see {@see $defaultOptions}
      */
-    protected static function createPantherClient(array $options = [], array $kernelOptions = [], array $managerOptions = []/*, array $browserArguments = []*/): PantherClient
+    protected static function createPantherClient(array $options = [], array $kernelOptions = [], array $managerOptions = []): PantherClient
     {
-        if (\func_num_args() < 4 && __CLASS__ !== (new \ReflectionClass(static::class))->getName() && __CLASS__ !== (new \ReflectionMethod(static::class, __FUNCTION__))->getDeclaringClass()->getName()) {
-            @trigger_error(sprintf('The "%s()" method will have a new "array $browserArguments = []" argument in version 1.1.0, not defining it is deprecated since Symfony 1.0.1.', __METHOD__), \E_USER_DEPRECATED);
-        }
-
-        $browserArguments = 3 < \func_num_args() ? \func_get_arg(3) : [];
-
         $browser = ($options['browser'] ?? self::$defaultOptions['browser'] ?? static::CHROME);
         $callGetClient = \is_callable([self::class, 'getClient']) && (new \ReflectionMethod(self::class, 'getClient'))->isStatic();
         if (null !== self::$pantherClient) {
@@ -167,13 +161,9 @@ trait PantherTestCaseTrait
             }
         }
 
-        // Only allow browser arguments if a browser has been explicitly specified
-        if (\is_array($browserArguments) && !\array_key_exists('browser', $options)) {
-            @trigger_error('Specifying $browserArguments requires that you specifically set the browser in $options. $browserArguments will be ignored.', \E_USER_WARNING);
-            $browserArguments = [];
-        }
-
         self::startWebServer($options);
+
+        $browserArguments = \array_key_exists('browser_arguments', $options) && \is_array($options['browser_arguments']) ? $options['browser_arguments'] : [];
 
         if (static::CHROME === $browser) {
             self::$pantherClients[0] = self::$pantherClient = Client::createChromeClient(null, $browserArguments, $managerOptions, self::$baseUri);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -53,11 +53,8 @@ class ClientTest extends TestCase
         $this->assertInstanceOf(JavaScriptExecutor::class, $client);
         $this->assertInstanceOf(KernelInterface::class, self::$kernel);
 
-        // I'm not sure exactly how to start with a clear class, since the
-        // test file assumes the client will be present for the next tests
-        // So I'm cleaning up this way here so that we can have a default
-        // client next
-        self::$pantherClient = null;
+        // stop the web server and clean up self::$pantherClient so it is not reused by other tests
+        $this->stopWebServer();
     }
 
     public function testCreateClient(): void

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -41,6 +41,26 @@ class ClientTest extends TestCase
         $this->assertInstanceOf(KernelInterface::class, self::$kernel);
     }
 
+    public function testCreatePantherClientWithBrowserArgument(): void
+    {
+        $client = self::createPantherClient([
+            'browser_arguments' => ['--window-size=1400,900'],
+        ]);
+        $this->assertInstanceOf(AbstractBrowser::class, $client);
+        $this->assertInstanceOf(WebDriver::class, $client);
+        $this->assertInstanceOf(JavaScriptExecutor::class, $client);
+        $this->assertInstanceOf(KernelInterface::class, self::$kernel);
+    }
+
+    public function testCreatePantherClientInvalidArgument(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $client = self::createPantherClient([
+            'browser_arguments' => 'bad browser arguments data type',
+        ]);
+    }
+
     public function testWaitForEmptyLocator(): void
     {
         $this->expectException(InvalidSelectorException::class);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Panther\Client;
 use Symfony\Component\Panther\Cookie\CookieJar;
 use Symfony\Component\Panther\DomCrawler\Crawler;
+use Symfony\Component\Panther\PantherTestCase;
 use Symfony\Component\Panther\ProcessManager\ChromeManager;
 
 /**
@@ -32,6 +33,33 @@ use Symfony\Component\Panther\ProcessManager\ChromeManager;
  */
 class ClientTest extends TestCase
 {
+    public function testCreatePantherClientInvalidArgument(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        self::createPantherClient([
+            'browser_arguments' => 'bad browser arguments data type',
+        ]);
+    }
+
+    public function testCreatePantherClientWithBrowserArgument(): void
+    {
+        $client = self::createPantherClient([
+            'browser' => PantherTestCase::CHROME,
+            'browser_arguments' => ['--window-size=1400,900'],
+        ]);
+        $this->assertInstanceOf(AbstractBrowser::class, $client);
+        $this->assertInstanceOf(WebDriver::class, $client);
+        $this->assertInstanceOf(JavaScriptExecutor::class, $client);
+        $this->assertInstanceOf(KernelInterface::class, self::$kernel);
+
+        // I'm not sure exactly how to start with a clear class, since the
+        // test file assumes the client will be present for the next tests
+        // So I'm cleaning up this way here so that we can have a default
+        // client next
+        self::$pantherClient = null;
+    }
+
     public function testCreateClient(): void
     {
         $client = self::createPantherClient();
@@ -39,26 +67,6 @@ class ClientTest extends TestCase
         $this->assertInstanceOf(WebDriver::class, $client);
         $this->assertInstanceOf(JavaScriptExecutor::class, $client);
         $this->assertInstanceOf(KernelInterface::class, self::$kernel);
-    }
-
-    public function testCreatePantherClientWithBrowserArgument(): void
-    {
-        $client = self::createPantherClient([
-            'browser_arguments' => ['--window-size=1400,900'],
-        ]);
-        $this->assertInstanceOf(AbstractBrowser::class, $client);
-        $this->assertInstanceOf(WebDriver::class, $client);
-        $this->assertInstanceOf(JavaScriptExecutor::class, $client);
-        $this->assertInstanceOf(KernelInterface::class, self::$kernel);
-    }
-
-    public function testCreatePantherClientInvalidArgument(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-
-        $client = self::createPantherClient([
-            'browser_arguments' => 'bad browser arguments data type',
-        ]);
     }
 
     public function testWaitForEmptyLocator(): void


### PR DESCRIPTION
Adds ability to pass browser arguments to the client when a Browser has been specified in the options.

According to what we were able to discuss in #428 , there isn't a clear way to configure a browser window size for the browser (assuming we want to test in interactive mode) from `createPantherClient`.

I commented the following in the issue, looking for answers to this:

```
It would appear by looking at the source code (if I'm not wrong) that if
I call Client::createChromeClient I won't have started a
WebServer (which I guess it's fine in my case, but not ALL cases) and I
won't boot a kernel. What implications does this have for
the test case?
```

Regardless of the implications, I think this is probably a good addition: We can reach firefox/chrome options from `createPantherClient` instead of directly.

Since browser arguments are specific to browser type, I've added a check to nullify this argument IF a browser hasn't been specified by the user. I wonder if this is needed? If I pass a wrong argument to a browser, I suppose the driver will just ignore it and move on.

Let me know if this is a sensible addition or if there is a better way to handle this.