### PR TITLE
ServerTrait: Don't check isWebServerStarted on pause

### DIFF
--- a/src/ServerTrait.php
+++ b/src/ServerTrait.php
@@ -34,8 +34,7 @@ trait ServerTrait
 
     private function pause($message): void
     {
-        if (PantherTestCase::isWebServerStarted()
-            && \in_array('--debug', $_SERVER['argv'], true)
+        if (\in_array('--debug', $_SERVER['argv'], true)
             && $_SERVER['PANTHER_NO_HEADLESS'] ?? false
         ) {
             echo "$message\n\nPress enter to continue...";


### PR DESCRIPTION
For the long story, check #427 .

After some investigation, I've found out that we aren't really testing weather a browser window stays open after a test failure or error (this might be untestable, tbf):

(From the issue posts)

------

I've found the test that is supposed to check weather the browser will be paused on test failure. The problem with the test itself is that it skips calling `$this->pause(sprintf('Failure: %s', $message));`:

```php
public function testPauseOnFailure(string $method, string $expected): void
{
    $extension = new ServerExtension();
    $extension->testing = true;
    ...
```

In the beginning of the test, the flag `$extension->testing` is set. Later, in `pause()` we see this:

```php
if (!$this->testing) {
    fgets(\STDIN);
}
```

And this is why a test wouldn't cover the issue reported here. So I added some `echo` lines throughout the code to debug a little bit and I've found out that in my particular case, when I reach the test failure, `PantherTestCase::isWebServerStarted()` is `false`, so the pause is never done:

(with my debug lines)
```php
private function pause($message): void
{
    echo PantherTestCase::isWebServerStarted() ? "Web server started\n" : "Web server hasn't started!!\n";

    if (PantherTestCase::isWebServerStarted()
        && \in_array('--debug', $_SERVER['argv'], true)
        && $_SERVER['PANTHER_NO_HEADLESS'] ?? false
    ) {
        echo "$message\n\nPress enter to continue...";
        if (!$this->testing) {
            fgets(\STDIN);
        }
    }
}
```

And the output is:

```
Testing /home/shadowc/web-local/decoramemas/tests/e2e
Test 'App\Tests\e2e\AdminBasicTest::testBasicAdminPageLoads' started
Web server hasn't started!!
Test 'App\Tests\e2e\AdminBasicTest::testBasicAdminPageLoads' ended
```

Thus the pause isn't performed.

-----------

By just removing that check in `pause` I was able to make the browser window stick after a test error or failure.