### PR TITLE
Allow options chromeManager

### DIFF
--- a/src/ProcessManager/ChromeManager.php
+++ b/src/ProcessManager/ChromeManager.php
@@ -60,9 +60,13 @@ final class ChromeManager implements BrowserManagerInterface
         }
 
         if ($this->arguments) {
-            $chromeOptions = new ChromeOptions();
+            $chromeOptions = $capabilities->getCapability(ChromeOptions::CAPABILITY);
+            if (null === $chromeOptions) {
+                $chromeOptions = new ChromeOptions();
+                $capabilities->setCapability(ChromeOptions::CAPABILITY, $chromeOptions);
+            }
             $chromeOptions->addArguments($this->arguments);
-            $capabilities->setCapability(ChromeOptions::CAPABILITY, $chromeOptions);
+
             if (isset($_SERVER['PANTHER_CHROME_BINARY'])) {
                 $chromeOptions->setBinary($_SERVER['PANTHER_CHROME_BINARY']);
             }


### PR DESCRIPTION
Allows the possibilities to pass options to the ChromeManager.
We can't do any test because the passed capabilities are discarded by the RemoveWebDriver.