### PR TITLE
Allow custom environment variables

### DIFF
--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -74,7 +74,7 @@ trait PantherTestCaseTrait
         'external_base_uri' => null,
         'readinessPath' => '',
         'browser' => PantherTestCase::CHROME,
-        'environmentVariables' => [],
+        'env' => [],
     ];
 
     public static function tearDownAfterClass(): void
@@ -130,7 +130,7 @@ trait PantherTestCaseTrait
             'port' => (int) ($options['port'] ?? $_SERVER['PANTHER_WEB_SERVER_PORT'] ?? self::$defaultOptions['port']),
             'router' => $options['router'] ?? $_SERVER['PANTHER_WEB_SERVER_ROUTER'] ?? self::$defaultOptions['router'],
             'readinessPath' => $options['readinessPath'] ?? $_SERVER['PANTHER_READINESS_PATH'] ?? self::$defaultOptions['readinessPath'],
-            'environmentVariables' => (array) ($options['environmentVariables'] ?? self::$defaultOptions['environmentVariables']),
+            'env' => (array) ($options['env'] ?? self::$defaultOptions['env']),
         ];
 
         self::$webServerManager = new WebServerManager(...array_values($options));

--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -74,6 +74,7 @@ trait PantherTestCaseTrait
         'external_base_uri' => null,
         'readinessPath' => '',
         'browser' => PantherTestCase::CHROME,
+        'environmentVariables' => [],
     ];
 
     public static function tearDownAfterClass(): void
@@ -129,6 +130,7 @@ trait PantherTestCaseTrait
             'port' => (int) ($options['port'] ?? $_SERVER['PANTHER_WEB_SERVER_PORT'] ?? self::$defaultOptions['port']),
             'router' => $options['router'] ?? $_SERVER['PANTHER_WEB_SERVER_ROUTER'] ?? self::$defaultOptions['router'],
             'readinessPath' => $options['readinessPath'] ?? $_SERVER['PANTHER_READINESS_PATH'] ?? self::$defaultOptions['readinessPath'],
+            'environmentVariables' => (array) ($options['environmentVariables'] ?? self::$defaultOptions['environmentVariables']),
         ];
 
         self::$webServerManager = new WebServerManager(...array_values($options));


### PR DESCRIPTION
Make the sixth parameter ($env) of the WebServerManager class configurable. 
Very useful to call e.g. different test_case.