### PR TITLE
Option for disable devtools

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ The following environment variables can be set to change some Panther's behaviou
 * `PANTHER_EXTERNAL_BASE_URI`: to use an external web server (the PHP built-in web server will not be started)
 * `PANTHER_APP_ENV`: to override the `APP_ENV` variable passed to the web server running the PHP app
 * `PANTHER_ERROR_SCREENSHOT_DIR`: to set a base directory for your failure/error screenshots (e.g. `./var/error-screenshots`)
+* `PANTHER_DEVTOOLS`: to toggle the browser's dev tools (default `enabled`, useful to debug)
 
 ### Changing the Hostname and Port of the Built-in Web Server
 

--- a/src/ProcessManager/ChromeManager.php
+++ b/src/ProcessManager/ChromeManager.php
@@ -93,7 +93,7 @@ final class ChromeManager implements BrowserManagerInterface
         $args = [];
 
         // Enable the headless mode unless PANTHER_NO_HEADLESS is defined
-        if (($_SERVER['PANTHER_NO_HEADLESS'] ?? false) == false) {
+        if ($_SERVER['PANTHER_NO_HEADLESS'] ?? false) {
             $args[] = '--headless';
             $args[] = '--window-size=1200,1100';
             $args[] = '--disable-gpu';

--- a/src/ProcessManager/ChromeManager.php
+++ b/src/ProcessManager/ChromeManager.php
@@ -90,8 +90,19 @@ final class ChromeManager implements BrowserManagerInterface
 
     private function getDefaultArguments(): array
     {
+        $args = [];
+
         // Enable the headless mode unless PANTHER_NO_HEADLESS is defined
-        $args = ($_SERVER['PANTHER_NO_HEADLESS'] ?? false) ? ['--auto-open-devtools-for-tabs'] : ['--headless', '--window-size=1200,1100', '--disable-gpu'];
+        if (($_SERVER['PANTHER_NO_HEADLESS'] ?? false) == false) {
+            $args[] = '--headless';
+            $args[] = '--window-size=1200,1100';
+            $args[] = '--disable-gpu';
+        }
+
+        // Enable devtools for debugging
+        if ($_SERVER['PANTHER_DEVTOOLS'] ?? true) {
+            $args[] = '--auto-open-devtools-for-tabs';
+        }
 
         // Disable Chrome's sandbox if PANTHER_NO_SANDBOX is defined or if running in Travis
         if ($_SERVER['PANTHER_NO_SANDBOX'] ?? $_SERVER['HAS_JOSH_K_SEAL_OF_APPROVAL'] ?? false) {

--- a/src/ProcessManager/FirefoxManager.php
+++ b/src/ProcessManager/FirefoxManager.php
@@ -89,8 +89,18 @@ final class FirefoxManager implements BrowserManagerInterface
 
     private function getDefaultArguments(): array
     {
+        $args = [];
+
         // Enable the headless mode unless PANTHER_NO_HEADLESS is defined
-        $args = ($_SERVER['PANTHER_NO_HEADLESS'] ?? false) ? ['--devtools'] : ['--headless', '--window-size=1200,1100'];
+        if (($_SERVER['PANTHER_NO_HEADLESS'] ?? false) == false) {
+            $args[] = '--headless';
+            $args[] = '--window-size=1200,1100';
+        }
+
+        // Enable devtools for debugging
+        if ($_SERVER['PANTHER_DEVTOOLS'] ?? true) {
+            $args[] = '--devtools';
+        }
 
         // Add custom arguments with PANTHER_FIREFOX_ARGUMENTS
         if ($_SERVER['PANTHER_FIREFOX_ARGUMENTS'] ?? false) {

--- a/src/ProcessManager/FirefoxManager.php
+++ b/src/ProcessManager/FirefoxManager.php
@@ -92,7 +92,7 @@ final class FirefoxManager implements BrowserManagerInterface
         $args = [];
 
         // Enable the headless mode unless PANTHER_NO_HEADLESS is defined
-        if (($_SERVER['PANTHER_NO_HEADLESS'] ?? false) == false) {
+        if ($_SERVER['PANTHER_NO_HEADLESS'] ?? false) {
             $args[] = '--headless';
             $args[] = '--window-size=1200,1100';
         }


### PR DESCRIPTION
Fixes #168

Changes are backwards compatible.

For disabling dev tools just add `PANTHER_DEVTOOLS=0` before the command or add it as a global server variable
```
PANTHER_DEVTOOLS=0 php bin/phpunit  
```
