### PR TITLE
Find the chromedriver installed by lanfest/binary-chromedriver

### DIFF
--- a/src/ProcessManager/ChromeManager.php
+++ b/src/ProcessManager/ChromeManager.php
@@ -81,7 +81,7 @@ final class ChromeManager implements BrowserManagerInterface
      */
     private function findChromeDriverBinary(): string
     {
-        if ($binary = (new ExecutableFinder())->find('chromedriver', null, ['./drivers'])) {
+        if ($binary = (new ExecutableFinder())->find('chromedriver', null, ['./drivers', './vendor/bin'])) {
             return $binary;
         }
 


### PR DESCRIPTION
Hey @fabpot 👋

`lanfest/binary-chromedriver` is a useful library that allows you to get a suitable chromedriver binary for the current operating system. The binary ends up in `vendor/bin/chromedriver`.

This PR will allow panther to automatically detect that binary :-)

