### PR TITLE
Fix registerClient in ServerExtension from consecutive createPantherClient calls

### DIFF
--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -157,6 +157,8 @@ trait PantherTestCaseTrait
                 (static::CHROME === $browser && $browserManager instanceof ChromeManager) ||
                 (static::FIREFOX === $browser && $browserManager instanceof FirefoxManager)
             ) {
+                ServerExtension::registerClient(self::$pantherClient);
+
                 return $callGetClient ? self::getClient(self::$pantherClient) : self::$pantherClient; // @phpstan-ignore-line
             }
         }

--- a/src/ServerExtension.php
+++ b/src/ServerExtension.php
@@ -35,7 +35,7 @@ final class ServerExtension implements BeforeFirstTestHook, AfterLastTestHook, B
 
     public static function registerClient(Client $client): void
     {
-        if (self::$enabled) {
+        if (self::$enabled && !in_array($client, self::$registeredClients, true)) {
             self::$registeredClients[] = $client;
         }
     }


### PR DESCRIPTION
When using `\Symfony\Component\Panther\ServerExtension` in phpunit config with a simple test class like that:

```php
class SomeTest extends \Symfony\Component\Panther\PantherTestCase
{
    public function testOne(): void
    {
        $client = self::createPantherClient();
        $client->request('GET', '/example');

        $this->assertFalse(true);
    }

    public function testTwo(): void
    {
        $client = self::createPantherClient();
        $client->request('GET', '/example');

        $this->assertFalse(true);
    }
}
```

only the first test will actually generate a screenshot in a `PANTHER_ERROR_SCREENSHOT_DIR` directory.

This happens always when using `createPantherClient`, because:
-  `createPantherClient` calls `ServerExtension::registerClient(self::$pantherClient);` only when `self::$pantherClient` is not set yet
-  `ServerExtension` clears list of registeredClient on every call to `ServerExtension::executeAfterTest` hook
- `self::$pantherClient` is cleared only on call to `stopWebServer`, which happens only in `ServerExtension::executeAfterLastTest` hook.

In this PR I've fixed that behaviour, so that every call to `createPantherClient` will register client in `ServerExtension`, as long as it's not already registered.