### PR TITLE
Add option to attach screenshots to phpunit junit report

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ The following environment variables can be set to change some Panther's behaviou
 * `PANTHER_EXTERNAL_BASE_URI`: to use an external web server (the PHP built-in web server will not be started)
 * `PANTHER_APP_ENV`: to override the `APP_ENV` variable passed to the web server running the PHP app
 * `PANTHER_ERROR_SCREENSHOT_DIR`: to set a base directory for your failure/error screenshots (e.g. `./var/error-screenshots`)
+* `PANTHER_ERROR_SCREENSHOT_ATTACH`: to add screenshots mentioned above to test output in junit attachment format
 
 ### Changing the Hostname and Port of the Built-in Web Server
 

--- a/src/PantherTestCase.php
+++ b/src/PantherTestCase.php
@@ -32,6 +32,7 @@ if (\class_exists(WebTestCase::class)) {
         private function doTearDown(): void
         {
             parent::tearDown();
+            $this->takeScreenshotIfTestFailed();
             self::getClient(null);
         }
     }
@@ -43,5 +44,11 @@ if (\class_exists(WebTestCase::class)) {
 
         public const CHROME = 'chrome';
         public const FIREFOX = 'firefox';
+
+        protected function tearDown(): void
+        {
+            parent::tearDown();
+            $this->takeScreenshotIfTestFailed();
+        }
     }
 }

--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Symfony\Component\Panther;
 
+use PHPUnit\Runner\BaseTestRunner;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\BrowserKit\HttpBrowser as HttpBrowserClient;
 use Symfony\Component\HttpClient\HttpClient;
@@ -140,6 +141,18 @@ trait PantherTestCaseTrait
     public static function isWebServerStarted(): bool
     {
         return self::$webServerManager && self::$webServerManager->isStarted();
+    }
+
+    public function takeScreenshotIfTestFailed(): void
+    {
+        if (!in_array($this->getStatus(), [BaseTestRunner::STATUS_ERROR, BaseTestRunner::STATUS_FAILURE])) {
+            return;
+        }
+
+        $type = $this->getStatus() === BaseTestRunner::STATUS_FAILURE ? 'failure' : 'error';
+        $test = $this->toString();
+
+        ServerExtension::takeScreenshots($type, $test);
     }
 
     /**


### PR DESCRIPTION
There is a fun little feature in gitlab, that allows to link to attached screenshot when showing test failure details:

![image](https://user-images.githubusercontent.com/6437642/119273012-41d2e580-bc09-11eb-8213-bf53e103ce2d.png)

After clicking link:

![image](https://user-images.githubusercontent.com/6437642/119272982-18b25500-bc09-11eb-9967-673e26807ced.png)

The screenshot has to be linked to in junit file, in the `<system-out>` element in a format `[[ATTACHMENT|./relative-url.png]]`, as described here: https://docs.gitlab.com/ee/ci/unit_test_reports.html#viewing-junit-screenshots-on-gitlab (note: for now documentation states that the path has to be absolute, but it's not true - there's an issue about it https://gitlab.com/gitlab-org/gitlab/-/issues/330951, I've tested it and the path has to be relative to build directory).

Example `<testcase>` entry in junit from gitlab documentation:

```
<testcase time="1.00" name="Test">
  <system-out>[[ATTACHMENT|/absolute/path/to/some/file]]</system-out>
</testcase>
```

It can actually easily be achieved by echoing this string during the test, phpunit picks that up when using junit log format. I'm proposing adding simple option `PANTHER_ERROR_SCREENSHOT_ATTACH` that would print such string, to allow using this with gitlab, and possibly with jenkins plugin https://plugins.jenkins.io/junit-attachments/ .

I've tried to get better support from phpunit for this attachment format, but it got nowhere: https://github.com/sebastianbergmann/phpunit/pull/4666

The only problem was that the screenshot cannot be taken in `executeAfterTestFailure`, as phpunit no longer treats output as test output then. I have moved screenshot taking to `tearDown`, and made `ServerExtension::takeScreenshots` public.

Would you consider adding such option to panther?