### PR TITLE
Fix screenshot name for tests with data provider

### DIFF
--- a/tests/ServerExtensionTest.php
+++ b/tests/ServerExtensionTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Symfony\Component\Panther\Tests;
 
+use Facebook\WebDriver\WebDriver;
 use Symfony\Component\Panther\PantherTestCase;
 use Symfony\Component\Panther\ServerExtension;
 
@@ -66,5 +67,19 @@ class ServerExtensionTest extends TestCase
     {
         yield ['executeAfterTestError', "Error: message\n\nPress enter to continue..."];
         yield ['executeAfterTestFailure', "Failure: message\n\nPress enter to continue..."];
+    }
+
+    public function testScreenshotTaking(): void
+    {
+        $clientMock = $this->createMock(WebDriver::class);
+        $clientMock->expects($this->once())
+                   ->method('takeScreenshot');
+
+        $problematicTestNameString = 'AcmeTest-EndToEnd-TestCases-Orders-Admin-AddOrderTest__testAddOrder with data set "europe/\@!;:\" (\'EUROPE_TEST_CLIENT\', AcmeTest-EndToEnd-Library-Modules-Orders-Admin-Add-Models-Initial-TransferObject-BillingInformation Object (...), AcmeTest-EndToEnd-Library-Modules-Orders-Admin-Add-Models-Initial-TransferObject-ShippingAddress Object (...), \'Another argument\', \'Last argument\')';
+        $actualFilePath = ServerExtension::takeClientScreenshot('screenshot_dir', 'failure', $problematicTestNameString, $clientMock, 1);
+        $this->assertStringEndsWith(
+            '_failure_AcmeTest-EndToEnd-TestCases-Orders-Admin-AddOrderTest__testAddOrder with data set europe-_- EUROPE_TEST_CLIENT AcmeTest-EndToEnd-Library-Modules-Order_afc257711399c8d413c87167d5fea6d1-1.png',
+            $actualFilePath
+        );
     }
 }


### PR DESCRIPTION
Fixes https://github.com/symfony/panther/issues/481

When using panther for tests with data provider, I've noticed that screenshots are not being made. While debugging I've noticed that there's an exception that's ignored by phpunit:

```
file_put_contents(data/panther_screenshots/2021-11-03_05-26-28_failure_AcmetTest-EndToEnd-TestCases-Orders-Admin-AddOrderTest__testAddOrder with data set "europe" ('TESTCLIENTAT', AcmeTest-EndToEnd-Library-Modules-Orders-Admin-Add-Models-Initial-TransferObject-BillingInformation Object (...), AcmeTest-EndToEnd-Library-Modules-Orders-Admin-Add-Models-Initial-TransferObject-ShippingAddress Object (...), 'PayU - transfer', 'Courier')-0.png): failed to open stream: File name too long
```

Apparently phpunit attaches all arguments to the test name when using `toString` method. To avoid that, we would have to use some methods marked as internal that might change without deprecation period.  So, instead, I've added slugification of the test name, and cut it to the first 150 characters (with all the other segments total filename length is now max 235 characters).
