### PR TITLE
Bumping branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-main": "1.0.x-dev"
+      "dev-main": "2.0.x-dev"
     }
   },
   "config": {


### PR DESCRIPTION
The current branch alias was actually incorrect (if we create a 1.x branch, we should fix that) - it causes Packagist to think that 1.1.1 > the latest commit - you can see this in the order of versions on the right - https://packagist.org/packages/symfony/panther.

This makes installing the Symfony 6 support for Panther difficult (`minimum-stability: "dev"` is not enough, because it thinks 1.1.1 is newer).

This should help us install Panther on Symfony UX tests, and make the `main` branch ready to be the "2.x" branch.