### PR TITLE
Support symfony/deprecation-contracts v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "ext-libxml": "*",
     "php-webdriver/webdriver": "^1.8.2",
     "symfony/browser-kit": "^4.4 || ^5.0 || ^6.0",
-    "symfony/deprecation-contracts": "^2.4",
+    "symfony/deprecation-contracts": "^2.4 || ^3.0",
     "symfony/dom-crawler": "^4.4 || ^5.0 || ^6.0",
     "symfony/http-client": "^4.4.11 || ^5.2 || ^6.0",
     "symfony/polyfill-php72": "^1.9",


### PR DESCRIPTION
v3.0 was released [8 days ago](https://github.com/symfony/deprecation-contracts/releases/tag/v3.0.0). When updating composer, it downgraded Panther because it doesn't support it yet:

```
/app # composer update
Loading composer repositories with package information
Updating dependencies
Lock file operations: 0 installs, 4 updates, 0 removals
  - Upgrading symfony/deprecation-contracts (v2.5.0 => v3.0.0)
  - Downgrading symfony/panther (v1.1.1 => v1.0.1)
```
