### PR TITLE
Remove polyfill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
     "symfony/dom-crawler": "^4.4 || ^5.0 || ^6.0",
     "symfony/http-client": "^4.4.11 || ^5.2 || ^6.0",
     "symfony/http-kernel": "^4.4 || ^5.0 || ^6.0",
-    "symfony/polyfill-php72": "^1.9",
     "symfony/process": "^4.4 || ^5.0 || ^6.0"
   },
   "autoload": {


### PR DESCRIPTION
On the main branch, we require PHP 8 or higher. I think, it's therefor safe to remove the PHP 7.2 polyfill.