### PR TITLE
Fix accessing `PantherTestCaseTrait::$webServerDir` before initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.0.1
+-----
+
+* Fix accessing `PantherTestCaseTrait::$webServerDir` before initialization
+
 2.0.0
 -----
 

--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -31,7 +31,7 @@ trait PantherTestCaseTrait
 {
     public static bool $stopServerOnTeardown = true;
 
-    protected static ?string $webServerDir;
+    protected static ?string $webServerDir = null;
 
     protected static ?WebServerManager $webServerManager = null;
 


### PR DESCRIPTION
`PantherTestCaseTrait::getWebServerDir()` can access `PantherTestCaseTrait::$webServerDir` before it's initialized. I believe this was just missed in #517.