### PR TITLE
Fix setValue on checkbox and select fields if they are multiple

### DIFF
--- a/src/DomCrawler/Field/ChoiceFormField.php
+++ b/src/DomCrawler/Field/ChoiceFormField.php
@@ -135,6 +135,9 @@ final class ChoiceFormField extends BaseChoiceFormField
             return;
         }
 
+        if ($this->selector->isMultiple()) {
+            $this->selector->deselectAll();
+        }
         foreach ((array) $value as $v) {
             $this->selector->selectByValue($v);
         }

--- a/tests/DomCrawler/Field/ChoiceFormFieldTest.php
+++ b/tests/DomCrawler/Field/ChoiceFormFieldTest.php
@@ -67,6 +67,21 @@ class ChoiceFormFieldTest extends TestCase
     /**
      * @dataProvider clientFactoryProvider
      */
+    public function testSetValueFromSelectMultipleIfOneIsSelectedAfterAllHaveBeenSelectedBefore(callable $clientFactory): void
+    {
+        $crawler = $this->request($clientFactory, '/choice-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        $field = $form['select_multiple_selected_all'];
+        $this->assertInstanceOf(ChoiceFormField::class, $field);
+        $this->assertSame(['10', '20', '30'], $field->getValue());
+        $field->setValue('20');
+        $this->assertSame(['20'], $field->getValue());
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
     public function testGetValueFromSelectMultipleIfMultipleIsSelected(callable $clientFactory): void
     {
         $crawler = $this->request($clientFactory, '/choice-form-field.html');
@@ -150,6 +165,26 @@ class ChoiceFormFieldTest extends TestCase
             $this->markTestSkipped('The DomCrawler component doesn\'t support multiple fields with the same name');
         }
         $this->assertSame(['checked_one', 'checked_two'], $field->getValue());
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testSetValueFromCheckboxIfOneIsCheckedAfterAllHaveBeenCheckedBefore(callable $clientFactory, string $type): void
+    {
+        $crawler = $this->request($clientFactory, '/choice-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        $field = $form['checkbox_multiple_checked'];
+
+        $this->assertInstanceOf(ChoiceFormField::class, $field);
+        // https://github.com/symfony/symfony/issues/26827
+        if (PantherClient::class !== $type) {
+            $this->markTestSkipped('The DomCrawler component doesn\'t support multiple fields with the same name');
+        }
+        $this->assertSame(['checked_one', 'checked_two'], $field->getValue());
+        $field->setValue('checked_two');
+        $this->assertSame('checked_two', $field->getValue());
     }
 
     /**

--- a/tests/fixtures/choice-form-field.html
+++ b/tests/fixtures/choice-form-field.html
@@ -41,6 +41,14 @@
         </select>
     </label>
 
+    <label class="field">
+        select_multiple_selected_all
+        <select name="select_multiple_selected_all" multiple="multiple">
+            <option value="10" selected>ten</option>
+            <option value="20" selected>twenty</option>
+            <option value="30" selected>thirty</option>
+        </select>
+    </label>
 
     <label class="field">
         select_multiple_selected_multiple


### PR DESCRIPTION
Currently ```ChoiceFormField::setValue``` is only able to add new values if the field is ```select``` or ```choice```.

This only-adding behavior:
- prevents the user from deselecting a value.
- prevents the user from 
- is not conform with ```ChoiceFormField::setValue``` of ```symfony-dom-crawler``` which resets the value of the field by the given value.

This PR unsets all previous values from given field before the given value is set.

PS: Do I have do take any action to get this PR into the ```main``` branch? :upside_down_face: