### PR TITLE
Implement coverage support

### DIFF
--- a/PantherCoverageKernelTrait.php
+++ b/PantherCoverageKernelTrait.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Panther project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Panther;
+
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\Driver\Selector;
+use SebastianBergmann\CodeCoverage\Filter;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+trait PantherCoverageKernelTrait
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function handle(Request $request, int $type = HttpKernelInterface::MAIN_REQUEST, bool $catch = true): Response
+    {
+        if ('true' === getenv('PANTHER_COVERAGE') && 'panther' === $this->environment) {
+            if (!class_exists(Filesystem::class)) {
+                throw new \LogicException('The Filesystem component is not installed. Try running "composer require --dev symfony/filesystem".');
+            }
+
+            $filter = new Filter();
+            $filter->includeDirectory(__DIR__.'/../src');
+
+            $coverage = new CodeCoverage(
+                (new Selector())->forLineCoverage($filter),
+                $filter
+            );
+
+            $coverage->start(md5(uniqid((string) mt_rand(), true)));
+        }
+
+        $response = parent::handle($request, $type, $catch);
+
+        if (true === isset($coverage)) {
+            $data = $coverage->stop();
+
+            $jsonCodeCoverageFile = md5(uniqid((string) mt_rand(), true)).'.code_coverage';
+
+            (new Filesystem())->appendToFile(PantherTestCase::COVERAGE_DIRECTORY.'/'.$jsonCodeCoverageFile, serialize($data));
+        }
+
+        return $response;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -495,6 +495,32 @@ class SecondDomainTest extends PantherTestCase
 }
 ```
 
+### Enable Code Coverage
+
+To enable code coverage with Panther usage, edit your `Kernel.php` file as follow:
+
+```php
+<?php
+
+namespace App;
+
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+use Symfony\Component\Panther\PantherCoverageKernelTrait;
+
+class Kernel extends BaseKernel
+{
+    use MicroKernelTrait;
+    use PantherCoverageKernelTrait;
+}
+```
+
+When running PhpUnit and want to have the coverage, enable it for Panther by passing the environment `PANTHER_COVERAGE=true`
+to enable it in the Symfony Kernel.
+
+**ℹ Note:** if you use Pcov as code coverage driver, you need to set `pcov.directory` in your `php.ini` file with the
+absolute path to your `src/` directory. By default, when using Panther it's defined on `public` directory.
+
 ### Using a Proxy
 
 To use a proxy server, set the following environment variable: `PANTHER_CHROME_ARGUMENTS='--proxy-server=socks://127.0.0.1:9050'`

--- a/src/PantherTestCase.php
+++ b/src/PantherTestCase.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestResult;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 
 if (class_exists(WebTestCase::class)) {
     abstract class PantherTestCase extends WebTestCase
@@ -44,10 +45,10 @@ if (class_exists(WebTestCase::class)) {
                 throw new \LogicException('The Finder component is not installed. Try running "composer require --dev symfony/finder".');
             }
 
-            /** @var \SplFileInfo[] $files */
+            /** @var SplFileInfo[] $files */
             $files = (new Finder())->in(self::COVERAGE_DIRECTORY)->files()->name('*.code_coverage');
             foreach ($files as $file) {
-                $content = file_get_contents($file->getRealPath());
+                $content = $file->getContents();
                 $rawCodeCoverageData = unserialize($content);
 
                 if (!empty($content)) {

--- a/src/PantherTestCase.php
+++ b/src/PantherTestCase.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace Symfony\Component\Panther;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestResult;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
 
 if (class_exists(WebTestCase::class)) {
     abstract class PantherTestCase extends WebTestCase
@@ -23,6 +26,39 @@ if (class_exists(WebTestCase::class)) {
 
         public const CHROME = 'chrome';
         public const FIREFOX = 'firefox';
+        public const COVERAGE_DIRECTORY = __DIR__.'/../var/panther-coverage';
+
+        public function run(TestResult $result = null): TestResult
+        {
+            $result = parent::run($result);
+
+            if (!is_dir(self::COVERAGE_DIRECTORY)) {
+                return $result;
+            }
+
+            if (!class_exists(Filesystem::class)) {
+                throw new \LogicException('The Filesystem component is not installed. Try running "composer require --dev symfony/filesystem".');
+            }
+
+            if (!class_exists(Finder::class)) {
+                throw new \LogicException('The Finder component is not installed. Try running "composer require --dev symfony/finder".');
+            }
+
+            /** @var \SplFileInfo[] $files */
+            $files = (new Finder())->in(self::COVERAGE_DIRECTORY)->files()->name('*.code_coverage');
+            foreach ($files as $file) {
+                $content = file_get_contents($file->getRealPath());
+                $rawCodeCoverageData = unserialize($content);
+
+                if (!empty($content)) {
+                    $result->getCodeCoverage()->append($rawCodeCoverageData, $this);
+                }
+            }
+
+            (new Filesystem())->remove(self::COVERAGE_DIRECTORY);
+
+            return $result;
+        }
 
         protected function tearDown(): void
         {


### PR DESCRIPTION
This PR try to implement Code Coverage support by using Panther when testing. The logic come from solutions given in #8, with some adaptation to be used with many Coverage Drivers: xdebug, pcov and phpdbg.

Actually I've not implements tests, just copy/paste my project implementation for review with some adaptations.