### PR TITLE
Allow input type checkbox without need to set attribute "name"

### DIFF
--- a/src/WebDriver/WebDriverCheckbox.php
+++ b/src/WebDriver/WebDriverCheckbox.php
@@ -50,13 +50,9 @@ class WebDriverCheckbox implements WebDriverSelectInterface
             throw new WebDriverException('The input must be of type "checkbox" or "radio".');
         }
 
-        if (null === $name = $element->getAttribute('name')) {
-            throw new WebDriverException('The input have a "name" attribute.');
-        }
-
         $this->element = $element;
         $this->type = $type;
-        $this->name = $name;
+        $this->name = $element->getAttribute('name');
     }
 
     public function isMultiple(): bool
@@ -231,6 +227,10 @@ class WebDriverCheckbox implements WebDriverSelectInterface
 
     private function getRelatedElements($value = null): array
     {
+        if (\is_null($this->name)) {
+            return [$this->element];
+        }
+
         $valueSelector = $value ? sprintf(' and @value = %s', XPathEscaper::escapeQuotes($value)) : '';
         if (null === $formId = $this->element->getAttribute('form')) {
             $form = $this->element->findElement(WebDriverBy::xpath('ancestor::form'));

--- a/tests/WebDriver/WebDriverCheckBoxTest.php
+++ b/tests/WebDriver/WebDriverCheckBoxTest.php
@@ -59,6 +59,29 @@ class WebDriverCheckBoxTest extends TestCase
         yield ['radio', ['j3a', 'j3b', 'j3c']];
     }
 
+    /**
+     * @dataProvider getOptionsDataProviderWithoutNameAttribute
+     */
+    public function testWebDriverCheckboxGetOptionsWithoutNameAttribute(string $type, array $options): void
+    {
+        $crawler = self::createPantherClient()->request('GET', self::$baseUri.'/choice-form-field-without-name-attribute.html');
+        $element = $crawler->filterXPath("//input[@type='$type']")->getElement(0);
+
+        $c = new WebDriverCheckbox($element);
+        $values = [];
+        foreach ($c->getOptions() as $option) {
+            $values[] = $option->getAttribute('value');
+        }
+
+        $this->assertSame($options, $values);
+    }
+
+    public function getOptionsDataProviderWithoutNameAttribute(): iterable
+    {
+        yield ['checkbox', ['noNameCheckbox']];
+        yield ['radio', ['noNameRadio']];
+    }
+
     public function testWebDriverCheckboxGetFirstSelectedOption(): void
     {
         $crawler = self::createPantherClient()->request('GET', self::$baseUri.'/form.html');
@@ -72,6 +95,21 @@ class WebDriverCheckBoxTest extends TestCase
         $c = new WebDriverCheckbox($radioElement);
         $c->selectByValue('j3a');
         $this->assertSame('j3a', $c->getFirstSelectedOption()->getAttribute('value'));
+    }
+
+    public function testWebDriverCheckboxGetFirstSelectedOptionWithoutNameAttribute(): void
+    {
+        $crawler = self::createPantherClient()->request('GET', self::$baseUri.'/choice-form-field-without-name-attribute.html');
+        $checkboxElement = $crawler->filterXPath('//input[@type="checkbox"]')->getElement(0);
+
+        $c = new WebDriverCheckbox($checkboxElement);
+        $c->selectByValue('noNameCheckbox');
+        $this->assertSame('noNameCheckbox', $c->getFirstSelectedOption()->getAttribute('value'));
+
+        $radioElement = $crawler->filterXPath('//input[@type="radio"]')->getElement(0);
+        $c = new WebDriverCheckbox($radioElement);
+        $c->selectByValue('noNameRadio');
+        $this->assertSame('noNameRadio', $c->getFirstSelectedOption()->getAttribute('value'));
     }
 
     /**

--- a/tests/fixtures/choice-form-field-without-name-attribute.html
+++ b/tests/fixtures/choice-form-field-without-name-attribute.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>ChoiceFormField without name attribute</title>
+</head>
+<body>
+
+<form>
+    <input type="radio" value="noNameRadio">
+    <input type="checkbox" value="noNameCheckbox">
+</form>
+
+</body>
+</html>


### PR DESCRIPTION
Currently all checkboxes must have a ```name``` attribute to be usable with ```symfony/panther``` and the ```ChoiceFormField```.

This PR allows instances of WebDriverCheckboxes without a ```name``` attribute, e.g.:
```
<input type="checkbox" value="noNameCheckbox">
```
