### PR TITLE
Void return

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -283,7 +283,7 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
         return new PantherCrawler($elements, $this->webDriver, $this->webDriver->getCurrentURL());
     }
 
-    protected function doRequest($request)
+    protected function doRequest($request): void
     {
         throw new \LogicException('Not useful in WebDriver mode.');
     }


### PR DESCRIPTION
Add void return type to functions with missing or empty return statements, but priority is given to @return annotations.