### PR TITLE
fix: ignore curl exceptions when closing webdriver inside destructor

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\Panther;
 
 use Facebook\WebDriver\Exception\NoSuchElementException;
 use Facebook\WebDriver\Exception\TimeoutException;
+use Facebook\WebDriver\Exception\WebDriverCurlException;
 use Facebook\WebDriver\JavaScriptExecutor;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\WebDriver;
@@ -105,7 +106,11 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
 
     public function __destruct()
     {
-        $this->quit();
+        try {
+            $this->quit();
+        } catch (WebDriverCurlException) {
+            // ignore
+        }
     }
 
     public function start(): void


### PR DESCRIPTION
Curl exceptions when quitting WebDriver are being thrown for different reasons, but are hard to handle since the method is called from inside the destructor.

The destructor is called when we are done with WebDriver anyway, and if there is an error quitting (most likely because WebDriver is not responding) we can safely ignore it IMO.

The try/catch is placed on purpose on the destructor only and not in the quit method so that when calling quit manually the exception can still be handled by the caller.