### PR TITLE
Add `loginUser()` helper method to Panther client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,10 @@
     "symfony/deprecation-contracts": "^2.4 || ^3",
     "symfony/dom-crawler": "^5.3 || ^6.0",
     "symfony/http-client": "^5.3 || ^6.0",
+    "symfony/http-foundation": "^5.3 || ^6.0",
     "symfony/http-kernel": "^5.3 || ^6.0",
-    "symfony/process": "^5.3 || ^6.0"
+    "symfony/process": "^5.3 || ^6.0",
+    "symfony/security-core": "^5.3 || ^6.0"
   },
   "autoload": {
     "psr-4": { "Symfony\\Component\\Panther\\": "src/" }

--- a/src/Client.php
+++ b/src/Client.php
@@ -541,7 +541,7 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
         // set a cookie to the uninitialised web driver. The path does not matter for this
         $this->request('GET', '/');
 
-        if(null === $sessionStorage) {
+        if (null === $sessionStorage) {
             $sessionStorage = new MockFileSessionStorage('/app/var/cache/panther/sessions');
         }
         $session = new Session($sessionStorage);


### PR DESCRIPTION
Please see [here](https://github.com/symfony/panther/issues/283) for discussion context

When doing E2E testing, it is common to need to login a user to perform certain actions. We often don't care about the login process for 99% of our tests, but we must still perform the steps each time. This can add unneccesary time and complexity onto the tests that could be avoided if only we had a way to simulate logins.

It would be nice to have a helper function named loginUser() similar to the [Application Test](https://symfony.com/doc/current/testing.html#application-tests) client. However, as we are doing E2E testing, we know that there is an added complexity of the environment settings of the alternate webserver (specifically how it handles session data). So, to solve this, we can pass SessionStorageInterface and firewallContext as arguments (but with sensisble defaults so they could be omitted in most cases).

Example of calling code would be:
```
$panther->logInUser(
    $user,
    new MockFileSessionStorage('/app/var/cache/panther/sessions'),
    'main'
);
```

Or simple (for most cases)

```
$panther->logInUser($user);
```

Have tested this approach (in userland code) and is working well for me. Was suggested in the discussion that I raise a PR for integration to Panther library code so here it is for your consideration. Please let me know if you need anything more from me.

Richard.