### PR TITLE
Improve DX when using the symfony binary

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -522,6 +522,11 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
 
         // Prepend the base URI to URIs without a host
         if (null !== $this->baseUri && (false !== $components = parse_url($url)) && !isset($components['host'])) {
+            if (str_starts_with($url, '/') && str_ends_with($this->baseUri, '/')) {
+                $url = substr($url, 1);
+            } elseif (!str_starts_with($url, '/') && !str_ends_with($this->baseUri, '/')) {
+                $url = '/'.$url;
+            }
             $url = $this->baseUri.$url;
         }
 


### PR DESCRIPTION
This PR improves the DX of using Panther when using the Symfony binary.

It improves the following:
- fix merging the base URI with the requested URL, adding/removing a slash between them as needed
- make the external URI default to `SYMFONY_PROJECT_DEFAULT_ROUTE_URL` when it's set
- auto-detect firefox when it's installed and chromium isn't
- ~accept insecure certs by default for firefox~

I spotted those when practicing the Symfony book:
https://symfony.com/doc/6.2/the-fast-track/en/17-tests.html
