### PR TITLE
Fix example for api-platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ $client = Client::createChromeClient();
 $client = Client::createFirefoxClient();
 
 $client->request('GET', 'https://api-platform.com'); // Yes, this website is 100% written in JavaScript
-$client->clickLink('Get started');
+$client->clickLink('Getting started');
 
 // Wait for an element to be present in the DOM (even if hidden)
 $crawler = $client->waitFor('#installing-the-framework');


### PR DESCRIPTION
The wording has changed on the remote site. the current example does not work anymore as Get has been replaced by Getting