### PR TITLE
Add missing arguments when calling the legacy extension

### DIFF
--- a/src/ServerExtension.php
+++ b/src/ServerExtension.php
@@ -78,7 +78,7 @@ if (interface_exists(Extension::class)) {
 
                 public function notify(TestStartedEvent $event): void
                 {
-                    $this->extension->executeBeforeTest();
+                    $this->extension->executeBeforeTest($event->test()->name());
                 }
             });
 
@@ -89,7 +89,7 @@ if (interface_exists(Extension::class)) {
 
                 public function notify(TestFinishedEvent $event): void
                 {
-                    $this->extension->executeAfterTest();
+                    $this->extension->executeAfterTest($event->test()->name(), (float) $event->telemetryInfo()->time()->seconds());
                 }
             });
 
@@ -100,7 +100,7 @@ if (interface_exists(Extension::class)) {
 
                 public function notify(Errored $event): void
                 {
-                    $this->extension->executeAfterTestError();
+                    $this->extension->executeAfterTestError($event->test()->name(), $event->throwable()->message(), (float) $event->telemetryInfo()->time()->seconds());
                 }
             });
 
@@ -111,7 +111,7 @@ if (interface_exists(Extension::class)) {
 
                 public function notify(Failed $event): void
                 {
-                    $this->extension->executeAfterTestFailure();
+                    $this->extension->executeAfterTestFailure($event->test()->name(), $event->throwable()->message(), (float) $event->telemetryInfo()->time()->seconds());
                 }
             });
         }


### PR DESCRIPTION
I'm getting a bunch of errors similar to what was reported in #608. Is it possible the fix is this simple? 

For the record, the errors are along the lines of:

```
Exception in third-party event subscriber: Symfony\Component\Panther\ServerExtensionLegacy::executeAfterTest(): Argument #2 ($time) must be of type float, PHPUnit\Event\Telemetry\HRTime given, called in /srv/app/vendor/symfony/panther/src/ServerExtension.php on line 92
#0 /srv/app/vendor/symfony/panther/src/ServerExtension.php(92): Symfony\Component\Panther\ServerExtensionLegacy->executeAfterTest('testUpdateValue', Object(PHPUnit\Event\Telemetry\HRTime))
#1 /srv/app/vendor/phpunit/phpunit/src/Event/Dispatcher/DirectDispatcher.php(100): PHPUnit\Event\Test\FinishedSubscriber@anonymous->notify(Object(PHPUnit\Event\Test\Finished))
#2 /srv/app/vendor/phpunit/phpunit/src/Event/Dispatcher/DeferringDispatcher.php(45): PHPUnit\Event\DirectDispatcher->dispatch(Object(PHPUnit\Event\Test\Finished))
#3 /srv/app/vendor/phpunit/phpunit/src/Event/Emitter/DispatchingEmitter.php(952): PHPUnit\Event\DeferringDispatcher->dispatch(Object(PHPUnit\Event\Test\Finished))
#4 /srv/app/vendor/phpunit/phpunit/src/Framework/TestRunner.php(238): PHPUnit\Event\DispatchingEmitter->testFinished(Object(PHPUnit\Event\Code\TestMethod), 1)
#5 /srv/app/vendor/phpunit/phpunit/src/Framework/TestCase.php(489): PHPUnit\Framework\TestRunner->run(Object(App\Tests\Service\ValueStoreServiceTest))
#6 /srv/app/vendor/phpunit/phpunit/src/Framework/TestSuite.php(340): PHPUnit\Framework\TestCase->run()
#7 /srv/app/vendor/phpunit/phpunit/src/Framework/TestSuite.php(340): PHPUnit\Framework\TestSuite->run()
#8 /srv/app/vendor/phpunit/phpunit/src/Framework/TestSuite.php(340): PHPUnit\Framework\TestSuite->run()
#9 /srv/app/vendor/phpunit/phpunit/src/TextUI/TestRunner.php(63): PHPUnit\Framework\TestSuite->run()
#10 /srv/app/vendor/phpunit/phpunit/src/TextUI/Application.php(189): PHPUnit\TextUI\TestRunner->run(Object(PHPUnit\TextUI\Configuration\Configuration), Object(PHPUnit\Runner\ResultCache\DefaultResultCache), Object(PHPUnit\Framework\TestSuite))
#11 /srv/app/vendor/phpunit/phpunit/phpunit(99): PHPUnit\TextUI\Application->run(Array)
#12 /srv/app/vendor/bin/phpunit(123): include('/srv/app/vendor...')
#13 {main}
```