### PR TITLE
fix: allow content to be empty when calling Crawler::html() method

### DIFF
--- a/src/DomCrawler/Crawler.php
+++ b/src/DomCrawler/Crawler.php
@@ -229,7 +229,7 @@ final class Crawler extends BaseCrawler implements WebDriverElement
                 return $this->webDriver->getPageSource();
             }
 
-            return $this->attr('outerHTML');
+            return (string) $this->attr('outerHTML');
         } catch (\InvalidArgumentException $e) {
             if (null === $default) {
                 throw $e;

--- a/src/DomCrawler/Crawler.php
+++ b/src/DomCrawler/Crawler.php
@@ -229,13 +229,13 @@ final class Crawler extends BaseCrawler implements WebDriverElement
                 return $this->webDriver->getPageSource();
             }
 
-            return $this->attr('outerHTML', $default);
+            return $this->attr('outerHTML', (string) $default);
         } catch (\InvalidArgumentException $e) {
             if (null === $default) {
                 throw $e;
             }
 
-            return (string) $default;
+            return $default;
         }
     }
 

--- a/src/DomCrawler/Crawler.php
+++ b/src/DomCrawler/Crawler.php
@@ -229,7 +229,7 @@ final class Crawler extends BaseCrawler implements WebDriverElement
                 return $this->webDriver->getPageSource();
             }
 
-            return (string) $this->attr('outerHTML');
+            return $this->attr('outerHTML', $default);
         } catch (\InvalidArgumentException $e) {
             if (null === $default) {
                 throw $e;

--- a/tests/DomCrawler/CrawlerTest.php
+++ b/tests/DomCrawler/CrawlerTest.php
@@ -391,7 +391,7 @@ class CrawlerTest extends TestCase
     public function testEmptyHtml(callable $clientFactory): void
     {
         $crawler = $this->request($clientFactory, '/basic.html');
-        $this->assertEmpty($crawler->filter('.empty')->html());
+        $this->assertEmpty($crawler->filter('.empty')->html(''));
     }
 
     /**

--- a/tests/DomCrawler/CrawlerTest.php
+++ b/tests/DomCrawler/CrawlerTest.php
@@ -242,7 +242,7 @@ class CrawlerTest extends TestCase
             $names[$i] = $c->nodeName();
         });
 
-        $this->assertSame(['h1', 'main', 'p', 'p', 'input', 'p'], $names);
+        $this->assertSame(['h1', 'main', 'p', 'p', 'input', 'p', 'div'], $names);
     }
 
     /**
@@ -383,6 +383,15 @@ class CrawlerTest extends TestCase
     {
         $crawler = $this->request($clientFactory, '/basic.html');
         $this->assertSame('default', $crawler->filter('header')->html('default'));
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testEmptyHtml(callable $clientFactory): void
+    {
+        $crawler = $this->request($clientFactory, '/basic.html');
+        $this->assertEmpty($crawler->filter('.empty')->html());
     }
 
     /**

--- a/tests/DomCrawler/CrawlerTest.php
+++ b/tests/DomCrawler/CrawlerTest.php
@@ -397,6 +397,15 @@ class CrawlerTest extends TestCase
     /**
      * @dataProvider clientFactoryProvider
      */
+    public function testEmptyHtmlWithoutDefault(callable $clientFactory): void
+    {
+        $crawler = $this->request($clientFactory, '/basic.html');
+        $this->assertEmpty($crawler->filter('.empty')->html());
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
     public function testNormalizeText(callable $clientFactory, string $clientClass): void
     {
         if (PantherClient::class !== $clientClass) {

--- a/tests/fixtures/basic.html
+++ b/tests/fixtures/basic.html
@@ -16,5 +16,6 @@
     <p class="p-2">P2</p>
     <input name="in" value="test">
     <p class="price" data-old-price="42">36</p>
+    <div class="empty"></div>
 </body>
 </html>


### PR DESCRIPTION
Hope that will fix the #615. 

Regards,

Sylvain