### PR TITLE
feat: allow selenium server with internal webserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,22 @@ class SecondDomainTest extends PantherTestCase
 
 To use a proxy server, set the following environment variable: `PANTHER_CHROME_ARGUMENTS='--proxy-server=socks://127.0.0.1:9050'`
 
+### Using Selenium With the Built-In Web Server
+
+If you want to use [Selenium Grid](https://www.selenium.dev/documentation/grid/) with the built-in web server, you need to configure the Panther client as follows:
+
+```php
+$client = Client::createPantherClient(
+    options: [
+        'browser' => PantherTestCase::SELENIUM,
+    ],
+    managerOptions: [
+        'host' => 'http://selenium-hub:4444', // the host of the Selenium Server (Grid)
+        'capabilities' => DesiredCapabilities::firefox(), // the capabilities of the browser
+    ],
+);
+```
+
 ### Accepting Self-signed SSL Certificates
 
 To force Chrome to accept invalid and self-signed certificates, set the following environment variable: `PANTHER_CHROME_ARGUMENTS='--ignore-certificate-errors'`

--- a/src/PantherTestCase.php
+++ b/src/PantherTestCase.php
@@ -23,6 +23,7 @@ if (class_exists(WebTestCase::class)) {
 
         public const CHROME = 'chrome';
         public const FIREFOX = 'firefox';
+        public const SELENIUM = 'selenium';
 
         protected function tearDown(): void
         {
@@ -44,6 +45,7 @@ if (class_exists(WebTestCase::class)) {
 
         public const CHROME = 'chrome';
         public const FIREFOX = 'firefox';
+        public const SELENIUM = 'selenium';
 
         protected function tearDown(): void
         {

--- a/src/PantherTestCaseTrait.php
+++ b/src/PantherTestCaseTrait.php
@@ -185,6 +185,8 @@ trait PantherTestCaseTrait
 
         if (PantherTestCase::FIREFOX === $browser) {
             self::$pantherClients[0] = self::$pantherClient = PantherClient::createFirefoxClient(null, $browserArguments, $managerOptions, self::$baseUri);
+        } elseif (PantherTestCase::SELENIUM === $browser) {
+            self::$pantherClients[0] = self::$pantherClient = PantherClient::createSeleniumClient($managerOptions['host'], $managerOptions['capabilities'] ?? null, self::$baseUri, $options);
         } else {
             try {
                 self::$pantherClients[0] = self::$pantherClient = PantherClient::createChromeClient(null, $browserArguments, $managerOptions, self::$baseUri);


### PR DESCRIPTION
Implements #590 by @dkarlovi.

This change allows the usage of an external selenium instance (e.g. via docker compose) to test against the internal webserver.

Todos:

- [ ] Tests
- [x] Documentation