### PR TITLE
Cast boolean env variables

### DIFF
--- a/src/ProcessManager/ChromeManager.php
+++ b/src/ProcessManager/ChromeManager.php
@@ -97,19 +97,19 @@ final class ChromeManager implements BrowserManagerInterface
         $args = [];
 
         // Enable the headless mode unless PANTHER_NO_HEADLESS is defined
-        if (!(filter_var($_SERVER['PANTHER_NO_HEADLESS'] ?? false, FILTER_VALIDATE_BOOLEAN))) {
+        if (!filter_var($_SERVER['PANTHER_NO_HEADLESS'] ?? false, \FILTER_VALIDATE_BOOLEAN)) {
             $args[] = '--headless';
             $args[] = '--window-size=1200,1100';
             $args[] = '--disable-gpu';
         }
 
         // Enable devtools for debugging
-        if (filter_var($_SERVER['PANTHER_DEVTOOLS'] ?? true, FILTER_VALIDATE_BOOLEAN)) {
+        if (filter_var($_SERVER['PANTHER_DEVTOOLS'] ?? true, \FILTER_VALIDATE_BOOLEAN)) {
             $args[] = '--auto-open-devtools-for-tabs';
         }
 
         // Disable Chrome's sandbox if PANTHER_NO_SANDBOX is defined or if running in Travis
-        if (filter_var($_SERVER['PANTHER_NO_SANDBOX'] ?? $_SERVER['HAS_JOSH_K_SEAL_OF_APPROVAL'] ?? false, FILTER_VALIDATE_BOOLEAN)) {
+        if (filter_var($_SERVER['PANTHER_NO_SANDBOX'] ?? $_SERVER['HAS_JOSH_K_SEAL_OF_APPROVAL'] ?? false, \FILTER_VALIDATE_BOOLEAN)) {
             // Running in Travis, disabling the sandbox mode
             $args[] = '--no-sandbox';
         }

--- a/src/ProcessManager/ChromeManager.php
+++ b/src/ProcessManager/ChromeManager.php
@@ -97,19 +97,19 @@ final class ChromeManager implements BrowserManagerInterface
         $args = [];
 
         // Enable the headless mode unless PANTHER_NO_HEADLESS is defined
-        if (!($_SERVER['PANTHER_NO_HEADLESS'] ?? false)) {
+        if (!(filter_var($_SERVER['PANTHER_NO_HEADLESS'] ?? false, FILTER_VALIDATE_BOOLEAN))) {
             $args[] = '--headless';
             $args[] = '--window-size=1200,1100';
             $args[] = '--disable-gpu';
         }
 
         // Enable devtools for debugging
-        if ($_SERVER['PANTHER_DEVTOOLS'] ?? true) {
+        if (filter_var($_SERVER['PANTHER_DEVTOOLS'] ?? true, FILTER_VALIDATE_BOOLEAN)) {
             $args[] = '--auto-open-devtools-for-tabs';
         }
 
         // Disable Chrome's sandbox if PANTHER_NO_SANDBOX is defined or if running in Travis
-        if ($_SERVER['PANTHER_NO_SANDBOX'] ?? $_SERVER['HAS_JOSH_K_SEAL_OF_APPROVAL'] ?? false) {
+        if (filter_var($_SERVER['PANTHER_NO_SANDBOX'] ?? $_SERVER['HAS_JOSH_K_SEAL_OF_APPROVAL'] ?? false, FILTER_VALIDATE_BOOLEAN)) {
             // Running in Travis, disabling the sandbox mode
             $args[] = '--no-sandbox';
         }

--- a/src/ProcessManager/FirefoxManager.php
+++ b/src/ProcessManager/FirefoxManager.php
@@ -92,12 +92,12 @@ final class FirefoxManager implements BrowserManagerInterface
         $args = [];
 
         // Enable the headless mode unless PANTHER_NO_HEADLESS is defined
-        if (!(filter_var($_SERVER['PANTHER_NO_HEADLESS'] ?? false, FILTER_VALIDATE_BOOLEAN))) {
+        if (!filter_var($_SERVER['PANTHER_NO_HEADLESS'] ?? false, \FILTER_VALIDATE_BOOLEAN)) {
             $args[] = '--headless';
         }
 
         // Enable devtools for debugging
-        if (filter_var($_SERVER['PANTHER_DEVTOOLS'] ?? true, FILTER_VALIDATE_BOOLEAN)) {
+        if (filter_var($_SERVER['PANTHER_DEVTOOLS'] ?? true, \FILTER_VALIDATE_BOOLEAN)) {
             $args[] = '--devtools';
         }
 

--- a/src/ProcessManager/FirefoxManager.php
+++ b/src/ProcessManager/FirefoxManager.php
@@ -92,12 +92,12 @@ final class FirefoxManager implements BrowserManagerInterface
         $args = [];
 
         // Enable the headless mode unless PANTHER_NO_HEADLESS is defined
-        if (!($_SERVER['PANTHER_NO_HEADLESS'] ?? false)) {
+        if (!(filter_var($_SERVER['PANTHER_NO_HEADLESS'] ?? false, FILTER_VALIDATE_BOOLEAN))) {
             $args[] = '--headless';
         }
 
         // Enable devtools for debugging
-        if ($_SERVER['PANTHER_DEVTOOLS'] ?? true) {
+        if (filter_var($_SERVER['PANTHER_DEVTOOLS'] ?? true, FILTER_VALIDATE_BOOLEAN)) {
             $args[] = '--devtools';
         }
 

--- a/src/ServerTrait.php
+++ b/src/ServerTrait.php
@@ -35,7 +35,7 @@ trait ServerTrait
     private function pause($message): void
     {
         if (\in_array('--debug', $_SERVER['argv'], true)
-            && (filter_var($_SERVER['PANTHER_NO_HEADLESS'] ?? false, FILTER_VALIDATE_BOOLEAN))
+            && filter_var($_SERVER['PANTHER_NO_HEADLESS'] ?? false, \FILTER_VALIDATE_BOOLEAN)
         ) {
             echo "$message\n\nPress enter to continue...";
             if (!$this->testing) {

--- a/src/ServerTrait.php
+++ b/src/ServerTrait.php
@@ -35,7 +35,7 @@ trait ServerTrait
     private function pause($message): void
     {
         if (\in_array('--debug', $_SERVER['argv'], true)
-            && ($_SERVER['PANTHER_NO_HEADLESS'] ?? false)
+            && (filter_var($_SERVER['PANTHER_NO_HEADLESS'] ?? false, FILTER_VALIDATE_BOOLEAN))
         ) {
             echo "$message\n\nPress enter to continue...";
             if (!$this->testing) {

--- a/tests/ServerExtensionTest.php
+++ b/tests/ServerExtensionTest.php
@@ -44,7 +44,7 @@ class ServerExtensionTest extends TestCase
 
         // stores current state
         $argv = $_SERVER['argv'];
-        $noHeadless = filter_var($_SERVER['PANTHER_NO_HEADLESS'] ?? false, FILTER_VALIDATE_BOOLEAN);
+        $noHeadless = filter_var($_SERVER['PANTHER_NO_HEADLESS'] ?? false, \FILTER_VALIDATE_BOOLEAN);
 
         self::startWebServer();
         $_SERVER['argv'][] = '--debug';

--- a/tests/ServerExtensionTest.php
+++ b/tests/ServerExtensionTest.php
@@ -44,7 +44,7 @@ class ServerExtensionTest extends TestCase
 
         // stores current state
         $argv = $_SERVER['argv'];
-        $noHeadless = $_SERVER['PANTHER_NO_HEADLESS'] ?? false;
+        $noHeadless = filter_var($_SERVER['PANTHER_NO_HEADLESS'] ?? false, FILTER_VALIDATE_BOOLEAN);
 
         self::startWebServer();
         $_SERVER['argv'][] = '--debug';


### PR DESCRIPTION
Inspired by [#164](https://github.com/symfony/panther/issues/168)

Environment variables are always casted to strings, so added PHP `filter_var()` to cast `$_SERVER` variables at if statements.

I think for argument `PANTHER_DEVTOOLS` its required to be able to set it to `false`, while for arguments `PANTHER_NO_HEADLESS` and `PANTHER_NO_SANDBOX` are `false` by default and `true` if they just defined.

Hence, another applicable solution is to convert `PANTHER_DEVTOOLS` to `PANTHER_NO_DEVTOOLS`