### PR TITLE
chore: do not set Firefox’ `window-size` option on headless mode

### DIFF
--- a/src/ProcessManager/FirefoxManager.php
+++ b/src/ProcessManager/FirefoxManager.php
@@ -94,7 +94,6 @@ final class FirefoxManager implements BrowserManagerInterface
         // Enable the headless mode unless PANTHER_NO_HEADLESS is defined
         if (!($_SERVER['PANTHER_NO_HEADLESS'] ?? false)) {
             $args[] = '--headless';
-            $args[] = '--window-size=1200,1100';
         }
 
         // Enable devtools for debugging


### PR DESCRIPTION
`--window-size` is described by the firefox CLI as “Width and optionally height of screenshot”. As such, it only has an effect when used with the `--screenshot` option.

Plus, Firefox has a default size of 1366×768 when running headless (can be changed by setting `MOZ_HEADLESS_WIDTH`/`HEIGHT` or by passing the `--width`/`--height` option to the CLI) so there is no need to explicitly set one.