### PR TITLE
feat: add PANTHER_REDUCED_MOTION to limit animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.2.0
+-----
+
+* Add a `PANTHER_REDUCED_MOTION` environment variable to instruct the website to minimize the amount of non-essential movement
+
 2.1.2
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 2.2.0
 -----
 
-* Add a `PANTHER_REDUCED_MOTION` environment variable to instruct the website to minimize the amount of non-essential movement
+* Add a `PANTHER_NO_REDUCED_MOTION` environment variable to instruct the website to disable the reduction of non-essential movement
 
 2.1.2
 -----

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ The following environment variables can be set to change some Panther's behavior
 * `PANTHER_ERROR_SCREENSHOT_DIR`: to set a base directory for your failure/error screenshots (e.g. `./var/error-screenshots`)
 * `PANTHER_DEVTOOLS`: to toggle the browser's dev tools (default `enabled`, useful to debug)
 * `PANTHER_ERROR_SCREENSHOT_ATTACH`: to add screenshots mentioned above to test output in junit attachment format
-* `PANTHER_REDUCED_MOTION`: to instruct the website to minimize the amount of non-essential movement
+* `PANTHER_NO_REDUCED_MOTION`: to instruct the website to disable the reduction of non-essential movement
 
 ### Changing the Hostname and Port of the Built-in Web Server
 

--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ The following environment variables can be set to change some Panther's behavior
 * `PANTHER_ERROR_SCREENSHOT_DIR`: to set a base directory for your failure/error screenshots (e.g. `./var/error-screenshots`)
 * `PANTHER_DEVTOOLS`: to toggle the browser's dev tools (default `enabled`, useful to debug)
 * `PANTHER_ERROR_SCREENSHOT_ATTACH`: to add screenshots mentioned above to test output in junit attachment format
+* `PANTHER_REDUCED_MOTION`: to instruct the website to minimize the amount of non-essential movement
 
 ### Changing the Hostname and Port of the Built-in Web Server
 

--- a/src/ProcessManager/ChromeManager.php
+++ b/src/ProcessManager/ChromeManager.php
@@ -116,7 +116,7 @@ final class ChromeManager implements BrowserManagerInterface
         }
 
         // Prefer reduced motion, see https://developer.mozilla.org/fr/docs/Web/CSS/@media/prefers-reduced-motion
-        if ($_SERVER['PANTHER_REDUCED_MOTION'] ?? false) {
+        if (filter_var($_SERVER['PANTHER_REDUCED_MOTION'] ?? true, \FILTER_VALIDATE_BOOLEAN)) {
             $args[] = '--force-prefers-reduced-motion';
         }
 

--- a/src/ProcessManager/ChromeManager.php
+++ b/src/ProcessManager/ChromeManager.php
@@ -116,7 +116,7 @@ final class ChromeManager implements BrowserManagerInterface
         }
 
         // Prefer reduced motion, see https://developer.mozilla.org/fr/docs/Web/CSS/@media/prefers-reduced-motion
-        if (filter_var($_SERVER['PANTHER_REDUCED_MOTION'] ?? true, \FILTER_VALIDATE_BOOLEAN)) {
+        if (!filter_var($_SERVER['PANTHER_NO_REDUCED_MOTION'] ?? false, \FILTER_VALIDATE_BOOLEAN)) {
             $args[] = '--force-prefers-reduced-motion';
         }
 

--- a/src/ProcessManager/ChromeManager.php
+++ b/src/ProcessManager/ChromeManager.php
@@ -115,7 +115,7 @@ final class ChromeManager implements BrowserManagerInterface
             $args[] = '--no-sandbox';
         }
 
-        // Prefer reduced motion, see https://developer.mozilla.org/fr/docs/Web/CSS/@media/prefers-reduced-motion
+        // Prefer reduced motion, see https://developer.mozilla.org/docs/Web/CSS/@media/prefers-reduced-motion
         if (!filter_var($_SERVER['PANTHER_NO_REDUCED_MOTION'] ?? false, \FILTER_VALIDATE_BOOLEAN)) {
             $args[] = '--force-prefers-reduced-motion';
         }

--- a/src/ProcessManager/ChromeManager.php
+++ b/src/ProcessManager/ChromeManager.php
@@ -115,6 +115,11 @@ final class ChromeManager implements BrowserManagerInterface
             $args[] = '--no-sandbox';
         }
 
+        // Prefer reduced motion, see https://developer.mozilla.org/fr/docs/Web/CSS/@media/prefers-reduced-motion
+        if ($_SERVER['PANTHER_REDUCED_MOTION'] ?? false) {
+            $args[] = '--force-prefers-reduced-motion';
+        }
+
         // Add custom arguments with PANTHER_CHROME_ARGUMENTS
         if ($_SERVER['PANTHER_CHROME_ARGUMENTS'] ?? false) {
             $arguments = explode(' ', $_SERVER['PANTHER_CHROME_ARGUMENTS']);

--- a/src/ProcessManager/FirefoxManager.php
+++ b/src/ProcessManager/FirefoxManager.php
@@ -54,19 +54,23 @@ final class FirefoxManager implements BrowserManagerInterface
             $this->waitUntilReady($this->process, $url.$this->options['path'], 'firefox');
         }
 
-        $capabilities = DesiredCapabilities::firefox();
-
-        /** @var FirefoxOptions $firefoxOptions */
-        $firefoxOptions = $capabilities->getCapability(FirefoxOptions::CAPABILITY);
+        $firefoxOptions = [];
         if (isset($_SERVER['PANTHER_FIREFOX_BINARY'])) {
-            $firefoxOptions->setOption('binary', $_SERVER['PANTHER_FIREFOX_BINARY']);
+            $firefoxOptions['binary'] = $_SERVER['PANTHER_FIREFOX_BINARY'];
         }
         if ($this->arguments) {
-            $firefoxOptions->addArguments($this->arguments);
+            $firefoxOptions['args'] = $this->arguments;
         }
+
+        $capabilities = DesiredCapabilities::firefox();
+        $capabilities->setCapability('moz:firefoxOptions', $firefoxOptions);
+
         // Prefer reduced motion, see https://developer.mozilla.org/fr/docs/Web/CSS/@media/prefers-reduced-motion
         if ($_SERVER['PANTHER_REDUCED_MOTION'] ?? false) {
-            $firefoxOptions->setPreference('ui.prefersReducedMotion', 'reduced');
+            /** @var FirefoxOptions|array $firefoxOptions */
+            $firefoxOptions = $capabilities->getCapability('moz:firefoxOptions') ?? [];
+            $firefoxOptions = $firefoxOptions instanceof FirefoxOptions ? $firefoxOptions->toArray() : $firefoxOptions;
+            $firefoxOptions['prefs']['ui.prefersReducedMotion'] = 'reduced';
         }
 
         foreach ($this->options['capabilities'] as $capability => $value) {

--- a/src/ProcessManager/FirefoxManager.php
+++ b/src/ProcessManager/FirefoxManager.php
@@ -66,11 +66,12 @@ final class FirefoxManager implements BrowserManagerInterface
         $capabilities->setCapability('moz:firefoxOptions', $firefoxOptions);
 
         // Prefer reduced motion, see https://developer.mozilla.org/fr/docs/Web/CSS/@media/prefers-reduced-motion
-        if (filter_var($_SERVER['PANTHER_REDUCED_MOTION'] ?? true, \FILTER_VALIDATE_BOOLEAN)) {
+        if (!filter_var($_SERVER['PANTHER_NO_REDUCED_MOTION'] ?? false, \FILTER_VALIDATE_BOOLEAN)) {
             /** @var FirefoxOptions|array $firefoxOptions */
             $firefoxOptions = $capabilities->getCapability('moz:firefoxOptions') ?? [];
             $firefoxOptions = $firefoxOptions instanceof FirefoxOptions ? $firefoxOptions->toArray() : $firefoxOptions;
-            $firefoxOptions['prefs']['ui.prefersReducedMotion'] = 'reduced';
+            $firefoxOptions['prefs']['ui.prefersReducedMotion'] = 1;
+            $capabilities->setCapability('moz:firefoxOptions', $firefoxOptions);
         }
 
         foreach ($this->options['capabilities'] as $capability => $value) {

--- a/src/ProcessManager/FirefoxManager.php
+++ b/src/ProcessManager/FirefoxManager.php
@@ -66,7 +66,7 @@ final class FirefoxManager implements BrowserManagerInterface
         $capabilities->setCapability('moz:firefoxOptions', $firefoxOptions);
 
         // Prefer reduced motion, see https://developer.mozilla.org/fr/docs/Web/CSS/@media/prefers-reduced-motion
-        if ($_SERVER['PANTHER_REDUCED_MOTION'] ?? false) {
+        if (filter_var($_SERVER['PANTHER_REDUCED_MOTION'] ?? true, \FILTER_VALIDATE_BOOLEAN)) {
             /** @var FirefoxOptions|array $firefoxOptions */
             $firefoxOptions = $capabilities->getCapability('moz:firefoxOptions') ?? [];
             $firefoxOptions = $firefoxOptions instanceof FirefoxOptions ? $firefoxOptions->toArray() : $firefoxOptions;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Symfony\Component\Panther\Tests;
 
+use Facebook\WebDriver\Exception\ElementClickInterceptedException;
 use Facebook\WebDriver\Exception\InvalidSelectorException;
 use Facebook\WebDriver\Exception\StaleElementReferenceException;
 use Facebook\WebDriver\Exception\TimeoutException;
@@ -576,5 +577,37 @@ JS
         self::createHttpBrowserClient([
             'http_client_options' => 'bad http client option data type',
         ]);
+    }
+
+    /**
+     * @dataProvider providePrefersReducedMotion
+     */
+    public function testPrefersReducedMotion(string $browser): void
+    {
+        $client = self::createPantherClient(['browser' => $browser]);
+        $client->request('GET', '/prefers-reduced-motion.html');
+
+        $client->clickLink('Click me!');
+        $this->assertStringEndsWith('#clicked', $client->getCurrentURL());
+    }
+
+    /**
+     * @dataProvider providePrefersReducedMotion
+     */
+    public function testPrefersReducedMotionDisabled(string $browser): void
+    {
+        $this->expectException(ElementClickInterceptedException::class);
+
+        $_SERVER['PANTHER_NO_REDUCED_MOTION'] = true;
+        $client = self::createPantherClient(['browser' => $browser]);
+        $client->request('GET', '/prefers-reduced-motion.html');
+
+        $client->clickLink('Click me!');
+    }
+
+    public function providePrefersReducedMotion(): iterable
+    {
+        yield 'Chrome' => [PantherTestCase::CHROME];
+        yield 'Firefox' => [PantherTestCase::FIREFOX];
     }
 }

--- a/tests/fixtures/prefers-reduced-motion.html
+++ b/tests/fixtures/prefers-reduced-motion.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>WaitFor</title>
+    <style>
+        #overlay {
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            background-color: rgba(0, 0, 0, 0.5);
+            animation: animation 5s forwards;
+        }
+
+        @keyframes animation {
+            from {
+                opacity: 1;
+            }
+            to {
+                opacity: 0;
+                visibility: hidden;
+            }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            #overlay {
+                animation: none;
+                opacity: 0;
+                visibility: hidden;
+            }
+        }
+    </style>
+</head>
+<body>
+<div id="overlay"></div>
+<a href="#clicked">Click me!</a>
+</body>
+</html>


### PR DESCRIPTION
This PR add a `PANTHER_REDUCED_MOTION` environment variable to set the `prefers-reduced-motion` CSS media feature to `reduce`.

It could be useful to limit "flaky" tests which result in a `Facebook\WebDriver\Exception\ElementClickInterceptedException: Element <XXX> is not clickable at point (XXX, YYY) because another element XXX obscures it` exception because an animation is still in progress.

This CSS media feature is already supported by [Bootstrap](https://getbootstrap.com/docs/4.1/getting-started/accessibility/#reduced-motion) or the french [DSFR](https://github.com/GouvernementFR/dsfr).