### PR TITLE
feat: add explicit error messages in "waitFor*" methods

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -346,7 +346,8 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
         $by = self::createWebDriverByFromLocator($locator);
 
         $this->wait($timeoutInSecond, $intervalInMillisecond)->until(
-            WebDriverExpectedCondition::presenceOfElementLocated($by)
+            WebDriverExpectedCondition::presenceOfElementLocated($by),
+            \sprintf('Element "%s" not found within %d seconds.', $locator, $timeoutInSecond),
         );
 
         return $this->crawler = $this->createCrawler();
@@ -365,7 +366,8 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
         $element = $this->findElement($by);
 
         $this->wait($timeoutInSecond, $intervalInMillisecond)->until(
-            WebDriverExpectedCondition::stalenessOf($element)
+            WebDriverExpectedCondition::stalenessOf($element),
+            \sprintf('Element "%s" did not become stale within %d seconds.', $locator, $timeoutInSecond),
         );
 
         return $this->crawler = $this->createCrawler();
@@ -382,7 +384,8 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
         $by = self::createWebDriverByFromLocator($locator);
 
         $this->wait($timeoutInSecond, $intervalInMillisecond)->until(
-            WebDriverExpectedCondition::visibilityOfElementLocated($by)
+            WebDriverExpectedCondition::visibilityOfElementLocated($by),
+            \sprintf('Element "%s" did not become visible within %d seconds.', $locator, $timeoutInSecond),
         );
 
         return $this->crawler = $this->createCrawler();
@@ -399,7 +402,8 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
         $by = self::createWebDriverByFromLocator($locator);
 
         $this->wait($timeoutInSecond, $intervalInMillisecond)->until(
-            WebDriverExpectedCondition::invisibilityOfElementLocated($by)
+            WebDriverExpectedCondition::invisibilityOfElementLocated($by),
+            \sprintf('Element "%s" did not become invisible within %d seconds.', $locator, $timeoutInSecond),
         );
 
         return $this->crawler = $this->createCrawler();
@@ -416,7 +420,8 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
         $by = self::createWebDriverByFromLocator($locator);
 
         $this->wait($timeoutInSecond, $intervalInMillisecond)->until(
-            WebDriverExpectedCondition::elementTextContains($by, $text)
+            WebDriverExpectedCondition::elementTextContains($by, $text),
+            \sprintf('Element "%s" did not contain "%s" within %d seconds.', $locator, $text, $timeoutInSecond),
         );
 
         return $this->crawler = $this->createCrawler();
@@ -433,7 +438,8 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
         $by = self::createWebDriverByFromLocator($locator);
 
         $this->wait($timeoutInSecond, $intervalInMillisecond)->until(
-            PantherWebDriverExpectedCondition::elementTextNotContains($by, $text)
+            PantherWebDriverExpectedCondition::elementTextNotContains($by, $text),
+            \sprintf('Element "%s" still contained "%s" after %d seconds.', $locator, $text, $timeoutInSecond),
         );
 
         return $this->crawler = $this->createCrawler();
@@ -450,7 +456,8 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
         $by = self::createWebDriverByFromLocator($locator);
 
         $this->wait($timeoutInSecond, $intervalInMillisecond)->until(
-            PantherWebDriverExpectedCondition::elementAttributeContains($by, $attribute, $text)
+            PantherWebDriverExpectedCondition::elementAttributeContains($by, $attribute, $text),
+            \sprintf('Element "%s" attribute "%s" did not contain "%s" within %d seconds.', $locator, $attribute, $text, $timeoutInSecond),
         );
 
         return $this->crawler = $this->createCrawler();
@@ -467,7 +474,8 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
         $by = self::createWebDriverByFromLocator($locator);
 
         $this->wait($timeoutInSecond, $intervalInMillisecond)->until(
-            PantherWebDriverExpectedCondition::elementAttributeNotContains($by, $attribute, $text)
+            PantherWebDriverExpectedCondition::elementAttributeNotContains($by, $attribute, $text),
+            \sprintf('Element "%s" attribute "%s" still contained "%s" after %d seconds.', $locator, $attribute, $text, $timeoutInSecond),
         );
 
         return $this->crawler = $this->createCrawler();
@@ -484,7 +492,8 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
         $by = self::createWebDriverByFromLocator($locator);
 
         $this->wait($timeoutInSecond, $intervalInMillisecond)->until(
-            PantherWebDriverExpectedCondition::elementEnabled($by)
+            PantherWebDriverExpectedCondition::elementEnabled($by),
+            \sprintf('Element "%s" did not become enabled within %d seconds.', $locator, $timeoutInSecond),
         );
 
         return $this->crawler = $this->createCrawler();
@@ -501,7 +510,8 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
         $by = self::createWebDriverByFromLocator($locator);
 
         $this->wait($timeoutInSecond, $intervalInMillisecond)->until(
-            PantherWebDriverExpectedCondition::elementDisabled($by)
+            PantherWebDriverExpectedCondition::elementDisabled($by),
+            \sprintf('Element "%s" did not become disabled within %d seconds.', $locator, $timeoutInSecond),
         );
 
         return $this->crawler = $this->createCrawler();

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\Panther\Tests;
 
 use Facebook\WebDriver\Exception\InvalidSelectorException;
 use Facebook\WebDriver\Exception\StaleElementReferenceException;
+use Facebook\WebDriver\Exception\TimeoutException;
 use Facebook\WebDriver\JavaScriptExecutor;
 use Facebook\WebDriver\WebDriver;
 use Facebook\WebDriver\WebDriverExpectedCondition;
@@ -185,6 +186,73 @@ class ClientTest extends TestCase
         $client->request('GET', '/waitfor-staleness.html');
         $crawler = $client->waitForStaleness($locator);
         $this->assertInstanceOf(Crawler::class, $crawler);
+    }
+
+    public static function waitForExceptionsProvider(): iterable
+    {
+        yield 'waitFor' => [
+            'waitFor',
+            ['locator' => '#not_found'],
+            'Element "#not_found" not found within 1 seconds.',
+        ];
+        yield 'waitForStaleness' => [
+            'waitForStaleness',
+            ['locator' => '#price'],
+            'Element "#price" did not become stale within 1 seconds.',
+        ];
+        yield 'waitForVisibility' => [
+            'waitForVisibility',
+            ['locator' => '#hidden'],
+            'Element "#hidden" did not become visible within 1 seconds.',
+        ];
+        yield 'waitForInvisibility' => [
+            'waitForInvisibility',
+            ['locator' => '#price'],
+            'Element "#price" did not become invisible within 1 seconds.',
+        ];
+        yield 'waitForElementToContain' => [
+            'waitForElementToContain',
+            ['locator' => '#price', 'text' => '36'],
+            'Element "#price" did not contain "36" within 1 seconds.',
+        ];
+        yield 'waitForElementToNotContain' => [
+            'waitForElementToNotContain',
+            ['locator' => '#price', 'text' => '42'],
+            'Element "#price" still contained "42" after 1 seconds.',
+        ];
+        yield 'waitForAttributeToContain' => [
+            'waitForAttributeToContain',
+            ['locator' => '#price', 'attribute' => 'data-old-price', 'text' => '42'],
+            'Element "#price" attribute "data-old-price" did not contain "42" within 1 seconds.',
+        ];
+        yield 'waitForAttributeToNotContain' => [
+            'waitForAttributeToNotContain',
+            ['locator' => '#price', 'attribute' => 'data-old-price', 'text' => '36'],
+            'Element "#price" attribute "data-old-price" still contained "36" after 1 seconds.',
+        ];
+        yield 'waitForEnabled' => [
+            'waitForEnabled',
+            ['locator' => '#disabled'],
+            'Element "#disabled" did not become enabled within 1 seconds.',
+        ];
+        yield 'waitForDisabled' => [
+            'waitForDisabled',
+            ['locator' => '#enabled'],
+            'Element "#enabled" did not become disabled within 1 seconds.',
+        ];
+    }
+
+    /**
+     * @dataProvider waitForExceptionsProvider
+     */
+    public function testWaitForExceptions(string $method, array $args, string $message): void
+    {
+        $this->expectException(TimeoutException::class);
+        $this->expectExceptionMessage($message);
+
+        $client = self::createPantherClient();
+        $client->request('GET', '/waitfor-exceptions.html');
+        $client->$method(...($args + ['timeoutInSecond' => 1]));
     }
 
     public function testExecuteScript(): void

--- a/tests/fixtures/waitfor-exceptions.html
+++ b/tests/fixtures/waitfor-exceptions.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>WaitFor - Exception</title>
+</head>
+<body>
+    <p id="price" data-old-price="36">42</p>
+    <p id="hidden" style="opacity: 0;">Hidden</p>
+    <input id="enabled" />
+    <input id="disabled" disabled />
+</body>
+</html>


### PR DESCRIPTION
Display an explicit message when a `waitFor*` assertion fails to make debug easier.