### PR TITLE
Used generic exception instead of WebDriverCurlException

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -15,7 +15,7 @@ namespace Symfony\Component\Panther;
 
 use Facebook\WebDriver\Exception\NoSuchElementException;
 use Facebook\WebDriver\Exception\TimeoutException;
-use Facebook\WebDriver\Exception\WebDriverCurlException;
+use Facebook\WebDriver\Exception\WebDriverException;
 use Facebook\WebDriver\JavaScriptExecutor;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\WebDriver;
@@ -110,7 +110,7 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
     {
         try {
             $this->quit();
-        } catch (WebDriverCurlException) {
+        } catch (WebDriverException) {
             // ignore
         }
     }


### PR DESCRIPTION
`WebDriverCurlException` as changed from `Facebook\WebDriver\Exception` to `Facebook\WebDriver\Exception\Internal` in php-webdriver 1.14.0.

Commit https://github.com/symfony/panther/commit/fed876ed0a43c3581b056b8f5132dc88738c2840 relies on `Facebook\WebDriver\Exception\WebDriverCurlException` witch is only valid for php-webdriver <= 1.13.1.

This PR use the more specific common exception to these 2 ones.

An other solution could be a use to `class_alias` but I don't think Panther has to manage BC break on php-webdriver.

