### PR TITLE
Fix reduced-motion tests on Windows

### DIFF
--- a/src/ProcessManager/ChromeManager.php
+++ b/src/ProcessManager/ChromeManager.php
@@ -118,6 +118,8 @@ final class ChromeManager implements BrowserManagerInterface
         // Prefer reduced motion, see https://developer.mozilla.org/docs/Web/CSS/@media/prefers-reduced-motion
         if (!filter_var($_SERVER['PANTHER_NO_REDUCED_MOTION'] ?? false, \FILTER_VALIDATE_BOOLEAN)) {
             $args[] = '--force-prefers-reduced-motion';
+        } else {
+            $args[] = '--force-prefers-no-reduced-motion';
         }
 
         // Add custom arguments with PANTHER_CHROME_ARGUMENTS

--- a/src/ProcessManager/FirefoxManager.php
+++ b/src/ProcessManager/FirefoxManager.php
@@ -66,13 +66,15 @@ final class FirefoxManager implements BrowserManagerInterface
         $capabilities->setCapability('moz:firefoxOptions', $firefoxOptions);
 
         // Prefer reduced motion, see https://developer.mozilla.org/fr/docs/Web/CSS/@media/prefers-reduced-motion
+        /** @var FirefoxOptions|array $firefoxOptions */
+        $firefoxOptions = $capabilities->getCapability('moz:firefoxOptions') ?? [];
+        $firefoxOptions = $firefoxOptions instanceof FirefoxOptions ? $firefoxOptions->toArray() : $firefoxOptions;
         if (!filter_var($_SERVER['PANTHER_NO_REDUCED_MOTION'] ?? false, \FILTER_VALIDATE_BOOLEAN)) {
-            /** @var FirefoxOptions|array $firefoxOptions */
-            $firefoxOptions = $capabilities->getCapability('moz:firefoxOptions') ?? [];
-            $firefoxOptions = $firefoxOptions instanceof FirefoxOptions ? $firefoxOptions->toArray() : $firefoxOptions;
             $firefoxOptions['prefs']['ui.prefersReducedMotion'] = 1;
-            $capabilities->setCapability('moz:firefoxOptions', $firefoxOptions);
+        } else {
+            $firefoxOptions['prefs']['ui.prefersReducedMotion'] = 0;
         }
+        $capabilities->setCapability('moz:firefoxOptions', $firefoxOptions);
 
         foreach ($this->options['capabilities'] as $capability => $value) {
             $capabilities->setCapability($capability, $value);


### PR DESCRIPTION
Fix [tests on Windows](https://github.com/symfony/panther/actions/runs/12673985132/job/35321595051) introduced by #651.

It was due to the Windows image which enables reduced motion at OS level by default.