### PR TITLE
fix: fix FirefoxManager capabilities merge logic

### DIFF
--- a/src/ProcessManager/FirefoxManager.php
+++ b/src/ProcessManager/FirefoxManager.php
@@ -54,33 +54,7 @@ final class FirefoxManager implements BrowserManagerInterface
             $this->waitUntilReady($this->process, $url.$this->options['path'], 'firefox');
         }
 
-        $firefoxOptions = [];
-        if (isset($_SERVER['PANTHER_FIREFOX_BINARY'])) {
-            $firefoxOptions['binary'] = $_SERVER['PANTHER_FIREFOX_BINARY'];
-        }
-        if ($this->arguments) {
-            $firefoxOptions['args'] = $this->arguments;
-        }
-
-        $capabilities = DesiredCapabilities::firefox();
-        $capabilities->setCapability('moz:firefoxOptions', $firefoxOptions);
-
-        // Prefer reduced motion, see https://developer.mozilla.org/fr/docs/Web/CSS/@media/prefers-reduced-motion
-        /** @var FirefoxOptions|array $firefoxOptions */
-        $firefoxOptions = $capabilities->getCapability('moz:firefoxOptions') ?? [];
-        $firefoxOptions = $firefoxOptions instanceof FirefoxOptions ? $firefoxOptions->toArray() : $firefoxOptions;
-        if (!filter_var($_SERVER['PANTHER_NO_REDUCED_MOTION'] ?? false, \FILTER_VALIDATE_BOOLEAN)) {
-            $firefoxOptions['prefs']['ui.prefersReducedMotion'] = 1;
-        } else {
-            $firefoxOptions['prefs']['ui.prefersReducedMotion'] = 0;
-        }
-        $capabilities->setCapability('moz:firefoxOptions', $firefoxOptions);
-
-        foreach ($this->options['capabilities'] as $capability => $value) {
-            $capabilities->setCapability($capability, $value);
-        }
-
-        return RemoteWebDriver::create($url, $capabilities, $this->options['connection_timeout_in_ms'] ?? null, $this->options['request_timeout_in_ms'] ?? null);
+        return RemoteWebDriver::create($url, $this->buildCapabilities(), $this->options['connection_timeout_in_ms'] ?? null, $this->options['request_timeout_in_ms'] ?? null);
     }
 
     public function quit(): void
@@ -121,6 +95,37 @@ final class FirefoxManager implements BrowserManagerInterface
         }
 
         return $args;
+    }
+
+    private function buildCapabilities(): DesiredCapabilities
+    {
+        $firefoxOptions = [];
+        if (isset($_SERVER['PANTHER_FIREFOX_BINARY'])) {
+            $firefoxOptions['binary'] = $_SERVER['PANTHER_FIREFOX_BINARY'];
+        }
+        if ($this->arguments) {
+            $firefoxOptions['args'] = $this->arguments;
+        }
+
+        $capabilities = DesiredCapabilities::firefox();
+        $capabilities->setCapability('moz:firefoxOptions', $firefoxOptions);
+
+        // Prefer reduced motion, see https://developer.mozilla.org/fr/docs/Web/CSS/@media/prefers-reduced-motion
+        /** @var FirefoxOptions|array $firefoxOptions */
+        $firefoxOptions = $capabilities->getCapability('moz:firefoxOptions') ?? [];
+        $firefoxOptions = $firefoxOptions instanceof FirefoxOptions ? $firefoxOptions->toArray() : $firefoxOptions;
+        if (!filter_var($_SERVER['PANTHER_NO_REDUCED_MOTION'] ?? false, \FILTER_VALIDATE_BOOLEAN)) {
+            $firefoxOptions['prefs']['ui.prefersReducedMotion'] = 1;
+        } else {
+            $firefoxOptions['prefs']['ui.prefersReducedMotion'] = 0;
+        }
+        $capabilities->setCapability('moz:firefoxOptions', $firefoxOptions);
+
+        foreach ($this->options['capabilities'] as $capability => $value) {
+            $capabilities->setCapability($capability, $value);
+        }
+
+        return $capabilities;
     }
 
     private function getDefaultOptions(): array

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -615,11 +615,18 @@ JS
     {
         $this->expectException(ElementClickInterceptedException::class);
 
+        $previous = $_SERVER['PANTHER_NO_REDUCED_MOTION'] ?? null;
         $_SERVER['PANTHER_NO_REDUCED_MOTION'] = true;
         $client = self::createPantherClient(['browser' => $browser]);
         $client->request('GET', '/prefers-reduced-motion.html');
 
         $client->clickLink('Click me!');
+
+        if (null === $previous) {
+            unset($_SERVER['PANTHER_NO_REDUCED_MOTION']);
+        } else {
+            $_SERVER['PANTHER_NO_REDUCED_MOTION'] = $previous;
+        }
     }
 
     public static function providePrefersReducedMotion(): iterable

--- a/tests/ProcessManager/FirefoxManagerTest.php
+++ b/tests/ProcessManager/FirefoxManagerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Panther project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Panther\Tests\ProcessManager;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Panther\Exception\RuntimeException;
+use Symfony\Component\Panther\ProcessManager\FirefoxManager;
+
+/**
+ * @author Tugdual Saunier <tugdual@saunier.tech>
+ */
+class FirefoxManagerTest extends TestCase
+{
+    public function testRun(): void
+    {
+        $manager = new FirefoxManager();
+        $client = $manager->start();
+        $this->assertNotEmpty($client->getCurrentURL());
+        $manager->quit();
+    }
+
+    public function testAlreadyRunning(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The port 4444 is already in use.');
+
+        $driver1 = new FirefoxManager();
+        $driver1->start();
+
+        $driver2 = new FirefoxManager();
+        try {
+            $driver2->start();
+        } finally {
+            $driver1->quit();
+        }
+    }
+
+    public function testNonDefaultPort(): void
+    {
+        $manager = new FirefoxManager(null, null, ['port' => 4445]);
+        $client = $manager->start();
+        $this->assertNotEmpty($client->getCurrentURL());
+        $manager->quit();
+    }
+
+    public function testMultipleInstances(): void
+    {
+        $driver1 = new FirefoxManager();
+        $client1 = $driver1->start();
+
+        $driver2 = new FirefoxManager(null, null, ['port' => 4445]);
+        $client2 = $driver2->start();
+
+        $this->assertNotEmpty($client1->getCurrentURL());
+        $this->assertNotEmpty($client2->getCurrentURL());
+
+        $driver1->quit();
+        $driver2->quit();
+    }
+}


### PR DESCRIPTION
Hi there!

While working on Firefox log capturing for a project (basically it requires setting `devtools.console.stdout.content` as `moz:firefoxOptions > pref`) I discovered the FirefoxManager behavior regarding options merging looked strange:
as soon as one sets the `moz:firefoxOptions` almost all the automation is gone (binary, args, and default prefs are gone).

While redefining most of them could be okay, this makes configuration via environment variables inoperant out of the blue, which is not in sync with how ChromeManager works.
This also drops the sensible defaults FirefoxOptions.

This MR tries to address this issue.

It is not easy (or even possible) to introspect the `moz:firefoxOptions` sent to the browser by connecting to it. I didn't find anywhere to hook into the library to check our required capabilities. This is why I took the liberty to introduce a new private method and access it via the reflection in the test suite. This is not the best but I don't see another way atm. Any suggestion is welcome!

(PS: I also added some basic tests for the `FirefoxManager` based on the `ChomeManager` ones)
