### PR TITLE
Allow to set option without value

### DIFF
--- a/src/DomCrawler/Field/ChoiceFormField.php
+++ b/src/DomCrawler/Field/ChoiceFormField.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Symfony\Component\Panther\DomCrawler\Field;
 
+use Facebook\WebDriver\Exception\NoSuchElementException;
 use Facebook\WebDriver\WebDriverSelect;
 use Facebook\WebDriver\WebDriverSelectInterface;
 use Symfony\Component\DomCrawler\Field\ChoiceFormField as BaseChoiceFormField;
@@ -42,7 +43,11 @@ final class ChoiceFormField extends BaseChoiceFormField
     public function select($value): void
     {
         foreach ((array) $value as $v) {
-            $this->selector->selectByValue($v);
+            try {
+                $this->selector->selectByValue($v);
+            } catch (NoSuchElementException) {
+                $this->selector->selectByVisibleText($v);
+            }
         }
     }
 
@@ -130,9 +135,7 @@ final class ChoiceFormField extends BaseChoiceFormField
             return;
         }
 
-        foreach ((array) $value as $v) {
-            $this->selector->selectByValue($v);
-        }
+        $this->select($value);
     }
 
     public function addChoice(\DOMElement $node): void

--- a/tests/DomCrawler/Field/ChoiceFormFieldTest.php
+++ b/tests/DomCrawler/Field/ChoiceFormFieldTest.php
@@ -95,6 +95,40 @@ class ChoiceFormFieldTest extends TestCase
     /**
      * @dataProvider clientFactoryProvider
      */
+    public function testGetValueFromSelectSingleWithoutValue(callable $clientFactory): void
+    {
+        $crawler = $this->request($clientFactory, '/choice-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var ChoiceFormField $field */
+        $field = $form['select_single_without_value'];
+        $this->assertInstanceOf(ChoiceFormField::class, $field);
+        $this->assertSame('none selected', $field->getValue());
+
+        $field->select('thirty');
+        $this->assertEquals('thirty', $field->getValue());
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
+    public function testGetValueFromSelectMultipleWithoutValue(callable $clientFactory): void
+    {
+        $crawler = $this->request($clientFactory, '/choice-form-field.html');
+        $form = $crawler->filter('form')->form();
+
+        /** @var ChoiceFormField $field */
+        $field = $form['select_multiple_without_value'];
+        $this->assertInstanceOf(ChoiceFormField::class, $field);
+        $this->assertSame([], $field->getValue());
+
+        $field->select('thirty');
+        $this->assertEquals(['thirty'], $field->getValue());
+    }
+
+    /**
+     * @dataProvider clientFactoryProvider
+     */
     public function testGetValueFromRadioIfSelected(callable $clientFactory): void
     {
         $crawler = $this->request($clientFactory, '/choice-form-field.html');

--- a/tests/fixtures/choice-form-field.html
+++ b/tests/fixtures/choice-form-field.html
@@ -60,6 +60,24 @@
         </select>
     </label>
 
+    <label class="field">
+        select_single_without_value
+        <select name="select_single_without_value">
+            <option>none selected</option>
+            <option id="single_without_20">twenty</option>
+            <option id="single_without_30">thirty</option>
+        </select>
+    </label>
+
+    <label class="field">
+        select_multiple_without_value
+        <select name="select_multiple_without_value" multiple="multiple">
+            <option>none selected</option>
+            <option id="multiple_without_20">twenty</option>
+            <option id="multiple_without_30">thirty</option>
+        </select>
+    </label>
+
     <div class="field">
         radio_checked
         <span><input type="radio" name="radio_checked" value="i_am_not_checked" />i_am_not_checked</span>


### PR DESCRIPTION
Currently all options must have a ```value``` attribute to be usable with ```symfony/panther``` and the ```ChoiceFormField```.

This PR allows instances of WebDriverCheckboxes without a ```value``` attribute, e.g.:
```
<option>ValueAsText</option>
```