### PR TITLE
Refactor exception handling while destructing the client.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "php": ">=8.0",
         "ext-dom": "*",
         "ext-libxml": "*",
-        "php-webdriver/webdriver": "^1.8.2",
+        "php-webdriver/webdriver": "^1.14.0",
         "symfony/browser-kit": "^5.4 || ^6.4 || ^7.0",
         "symfony/dependency-injection": "^5.4 || ^6.4 || ^7.0",
         "symfony/deprecation-contracts": "^2.4 || ^3",

--- a/src/Client.php
+++ b/src/Client.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Symfony\Component\Panther;
 
 use Facebook\WebDriver\Exception\NoSuchElementException;
+use Facebook\WebDriver\Exception\PhpWebDriverExceptionInterface;
 use Facebook\WebDriver\Exception\TimeoutException;
-use Facebook\WebDriver\Exception\WebDriverException;
 use Facebook\WebDriver\JavaScriptExecutor;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\WebDriver;
@@ -108,11 +108,7 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
 
     public function __destruct()
     {
-        try {
-            $this->quit();
-        } catch (WebDriverException) {
-            // ignore
-        }
+        $this->quit();
     }
 
     public function start(): void
@@ -602,8 +598,12 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
     public function quit(bool $quitBrowserManager = true): void
     {
         if (null !== $this->webDriver) {
-            $this->webDriver->quit();
-            $this->webDriver = null;
+            try {
+                $this->webDriver->quit();
+                $this->webDriver = null;
+            } catch (PhpWebDriverExceptionInterface) {
+                // ignore
+            }
         }
 
         if ($quitBrowserManager) {


### PR DESCRIPTION
While testing I stumbled over #466 again with errors like:

```
Failed to connect to 127.0.0.1 port 9515 after 0 ms: Couldn't connect to server in /builds/nsd-intern/dk_roadtodevops/project-examples/php/php-symfony-example/app/vendor/php-webdriver/webdriver/lib/Exception/Internal/WebDriverCurlException.php on line 20
```

I mentioned that the WebDriverCurlException doesn't inherit from WebDriverException and therefore wasn't caught.

While digging in the code, I'v found that php-webdriver/webdriver introduced a common exception interface in [1.14.0 (from 2023-02-09)](https://github.com/php-webdriver/php-webdriver/blob/main/CHANGELOG.md#1140---2023-02-09), so I though its safe/mature enough to bump the dependency version.

I also found out that if destructing of the Client fails, the BrowserManager will not quit, so I moved the exception handling for the webdriver exceptions into the actual quit method.