### PR TITLE
Use Fabbot in CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+| Q             | A
+| ------------- | ---
+| Bug fix?      | yes/no
+| New feature?  | yes/no
+| Deprecations? | yes/no
+| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
+| License       | MIT
+
+<!--
+🛠️ Replace this text with a concise explanation of your change:
+- What it does and why it's necessary
+- A simple example of how it works (include PHP, YAML, etc.)
+- If it modifies existing behavior, include a before/after comparison
+
+Contributor guidelines:
+- 📝 Add an entry to the changelog file
+- ✅ Add tests and ensure they pass
+- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
+- ✨ New features and deprecations must target the **feature** branch
+- 🔒 Do not break backward compatibility: https://symfony.com/bc
+-->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,22 +5,6 @@ on:
     pull_request:
 
 jobs:
-    php-cs-fixer:
-        runs-on: ubuntu-latest
-        name: Coding Standards
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v5
-
-            - name: Setup PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: '8.3'
-                  tools: php-cs-fixer, cs2pr
-
-            - name: PHP Coding Standards Fixer
-              run: php-cs-fixer fix --dry-run --diff
-
     phpstan:
         runs-on: ubuntu-latest
         name: Static Analysis

--- a/.github/workflows/fabbot.yaml
+++ b/.github/workflows/fabbot.yaml
@@ -1,0 +1,15 @@
+name: Fabbot
+
+on:
+    pull_request:
+
+permissions:
+    contents: read
+
+jobs:
+    call-fabbot:
+        name: Fabbot
+        uses: symfony-tools/fabbot/.github/workflows/fabbot.yml@main
+        with:
+            package: Panther
+            check_license: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Would using [symfony-tools/fabbot](https://github.com/symfony-tools/fabbot) to check the code style be a better option? As a bonus, it also runs additional checks.

I copied the PR template from the Monolog bundle.