### PR TITLE
#688 fix "Return type declaration must be compatible with parent" for Symfony7.4 + PHP 8.4

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -291,7 +291,7 @@ final class Client extends AbstractBrowser implements WebDriver, JavaScriptExecu
         return new PantherCrawler($elements, $this->webDriver, $this->webDriver->getCurrentURL());
     }
 
-    protected function doRequest($request)
+    protected function doRequest($request): object
     {
         throw new LogicException('Not useful in WebDriver mode.');
     }

--- a/src/DomCrawler/Crawler.php
+++ b/src/DomCrawler/Crawler.php
@@ -142,7 +142,7 @@ final class Crawler extends BaseCrawler implements WebDriverElement
         return $this->filterXPath($xpath)->count() > 0;
     }
 
-    public function closest(string $selector): ?self
+    public function closest(string $selector): ?static
     {
         $converter = $this->createCssSelectorConverter();
         $xpath = WebDriverBy::xpath($converter->toXPath($selector, 'self::'));


### PR DESCRIPTION
This would fix method signature for https://github.com/symfony/panther/issues/688 allowing installation with Symfony 7.4 and PHP 8.4 with a working implementation.

The main issue: Its then not compatible with 8.0, where the return type changed.

- https://github.com/symfony/dom-crawler/blob/v7.4.0/Crawler.php#L407
- https://github.com/symfony/dom-crawler/blob/v8.0.0/Crawler.php#L396

i don't how complex is case must be handled here and if there must be a solution supporting both with current version strategy. For our projects its fine as 7.4 would just be temporary step to 8.0. But 7.4 is the LTS, maybe it should have prio or provide 2 separate version tags. 


This allows a temporary step: `composer.json`

```
    {
      "type": "vcs",
      "url": "git@github.com:Haehnchen/panther.git"
    }

    "symfony/panther": "dev-feature/symfony7-4 as 2.3.0",
```


Fixing error logs:

```
[2026-01-05T10:20:20.965208+00:00] php.CRITICAL: Fatal Compile Error: Declaration of Symfony\Component\Panther\DomCrawler\Crawler::closest(string $selector): ?Symfony\Component\Panther\DomCrawler\Crawler must be compatible with Symfony\Component\DomCrawler\Crawler::closest(string $selector): ?static {"exception":"[object] (Symfony\\Component\\ErrorHandler\\Error\\FatalError(code: 0): Compile Error: Declaration of Symfony\\Component\\Panther\\DomCrawler\\Crawler::closest(string $selector): ?Symfony\\Component\\Panther\\DomCrawler\\Crawler must be compatible with Symfony\\Component\\DomCrawler\\Crawler::closest(string $selector): ?static at /.../vendor/symfony/panther/src/DomCrawler/Crawler.php:145)"} []
[2026-01-05T10:20:21.105305+00:00] php.CRITICAL: Fatal Compile Error: Declaration of Symfony\Component\Panther\DomCrawler\Crawler::closest(string $selector): ?Symfony\Component\Panther\DomCrawler\Crawler must be compatible with Symfony\Component\DomCrawler\Crawler::closest(string $selector): ?static {"exception":"[object] (Symfony\\Component\\ErrorHandler\\Error\\FatalError(code: 0): Compile Error: Declaration of Symfony\\Component\\Panther\\DomCrawler\\Crawler::closest(string $selector): ?Symfony\\Component\\Panther\\DomCrawler\\Crawler must be compatible with Symfony\\Component\\DomCrawler\\Crawler::closest(string $selector): ?static at /.../vendor/symfony/panther/src/DomCrawler/Crawler.php:145)"} []
```